### PR TITLE
Create various mame directories if they don't exist

### DIFF
--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -223,8 +223,8 @@ void retro_init (void)
 #ifdef LOG_PERFORMANCE
    environ_cb(RETRO_ENVIRONMENT_GET_PERF_INTERFACE, &perf_cb);
 #endif
-
-	update_variables();
+    
+   update_variables();
    check_system_specs();
 }
 

--- a/src/libretro/osd.c
+++ b/src/libretro/osd.c
@@ -221,6 +221,15 @@ osd_file *osd_fopen(int pathtype, int pathindex, const char *filename, const cha
       log_cb(RETRO_LOG_INFO, "osd_fopen (buffer = [%s]), (systemDir: [%s]), (path type dir: [%s]), (path: [%d]), (filename: [%s]) \n", buffer, systemDir, paths[pathtype], pathtype, filename);
 
    out = (osd_file*)malloc(sizeof(osd_file));
+    
+   if (osd_get_path_info(pathtype, pathindex, filename) == PATH_NOT_FOUND)
+   {
+       /* if path not found, create */
+       char newPath[1024];
+       snprintf(newPath, sizeof(newPath), "%s%c%s", systemDir, slash, paths[pathtype]);
+       mkdir(newPath, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+   }
+    
    out->file = fopen(buffer, mode);
 
    if(out->file == 0)


### PR DESCRIPTION
Ensure saving of .nvram, mame.cfg, game.cfg, etc, regardless of initial
directory structure. Latter allows useful interim solution until full
core input remapping is implemented.

(+ style nit)