### PR TITLE
Mapped mame directories to RA configured ones.

### DIFF
--- a/README
+++ b/README
@@ -1,12 +1,16 @@
-Proof on concept
+Proof of concept
 Based on MAME 0.78
 
 Tested for OS X, linux, Wii, and Android (arm-v7a).
 
+Generates directories as it requires:
+* User-generated content: Saves (NVRAM, MEMCARD), Hi-Scores, and Controller Config files are in sub-directories within the Retroarch Savefile Dir.
+* Everything else (Cheats, Mame INI, etc) in the Retroarch System/BIOS Dir.
+
 TODO:
 
-* Better path management. For now all games must be placed in a folder named 'rom'. Other folders must be created manually in 'rom's parent directory. Their names can be found under the File I/O section of src/libretro/osd.c.
 * Make sure all of the mkdir commands in makefile complete before any compiling starts.
+* Input Descriptors (for use in Core Input Remapping)
 * Lots more
 
 Notes:

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -130,8 +130,10 @@ extern struct osd_create_params videoConfig;
 
 unsigned retroColorMode;
 int16_t XsoundBuffer[2048];
-char* systemDir;
-char* romDir;
+char *fallbackDir;
+char *systemDir;
+char *romDir;
+char *saveDir;
 
 unsigned retro_api_version(void)
 {
@@ -223,7 +225,7 @@ void retro_init (void)
 #ifdef LOG_PERFORMANCE
    environ_cb(RETRO_ENVIRONMENT_GET_PERF_INTERFACE, &perf_cb);
 #endif
-    
+
    update_variables();
    check_system_specs();
 }
@@ -281,18 +283,37 @@ bool retro_load_game(const struct retro_game_info *game)
     
     if(driverIndex)
     {
+        fallbackDir = strdup(game->path);
+        //const char *fallbackDir = game->path;
         int orientation;
         unsigned rotateMode;
         static const int uiModes[] = {ROT0, ROT90, ROT180, ROT270};
-
-        // Get MAME Directory
-        systemDir = normalizePath(strdup(game->path));
+        
+        /* Get system directory from frontend */
+        environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY,&systemDir);
+        if (systemDir == NULL || systemDir[0] == 0)
+        {
+            /* if non set, use old method */
+            systemDir = normalizePath(fallbackDir);
+            systemDir = peelPathItem(systemDir);
+        }
+        /* remove trailing slash */
         systemDir = peelPathItem(systemDir);
-        systemDir = peelPathItem(systemDir);       
+        
+        /* Get save directory from frontend */
+        environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY,&saveDir);
+        if (saveDir == NULL || saveDir[0] == 0)
+        {
+            /* if non set, use old method */
+            saveDir = normalizePath(fallbackDir);
+            saveDir = peelPathItem(saveDir);
+        }
+        /* remove trailing slash */
+        saveDir = peelPathItem(saveDir);
 
         // Get ROM directory
-        romDir    = normalizePath(strdup(game->path));
-        romDir    = peelPathItem(romDir);
+        romDir = normalizePath(fallbackDir);
+        romDir = peelPathItem(romDir);
 
         // Setup Rotation
         orientation = drivers[driverIndex]->flags & ORIENTATION_MASK;
@@ -309,6 +330,7 @@ bool retro_load_game(const struct retro_game_info *game)
         options.ui_orientation = uiModes[rotateMode];
         options.vector_intensity = 1.5f;
         options.skip_disclaimer = skip_disclaimer;
+        options.use_samples = 1;
 
         // Boot the emulator
         return run_game(driverIndex) == 0;
@@ -323,7 +345,7 @@ void retro_unload_game(void)
 {
     mame_done();
     
-    free(systemDir);
+    free(fallbackDir);
     systemDir = 0;
 }
 

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -297,8 +297,6 @@ bool retro_load_game(const struct retro_game_info *game)
             systemDir = normalizePath(fallbackDir);
             systemDir = peelPathItem(systemDir);
         }
-        /* remove trailing slash */
-        systemDir = peelPathItem(systemDir);
         
         /* Get save directory from frontend */
         environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY,&saveDir);
@@ -308,8 +306,6 @@ bool retro_load_game(const struct retro_game_info *game)
             saveDir = normalizePath(fallbackDir);
             saveDir = peelPathItem(saveDir);
         }
-        /* remove trailing slash */
-        saveDir = peelPathItem(saveDir);
 
         // Get ROM directory
         romDir = normalizePath(fallbackDir);

--- a/src/ui_text.c
+++ b/src/ui_text.c
@@ -92,7 +92,7 @@ static const char *mame_default_text[] =
 #endif
 	"The game has protection which isn't fully emulated.",
 	"There are working clones of this game. They are:",
-	"Type OK to continue",
+    "Type OK on Keyboard, or Left, Right on Joystick to continue",
 
 	/* main menu */
 	"Input (general)",


### PR DESCRIPTION
1. Moved internal mame directories to:
- User-generated content: Saves (NVRAM, MEMCARD), Hi-Scores, and Controller Config files are in sub-directories within the Retroarch Savefile Dir.
- Everything else (Cheats, Mame INI, etc) in the Retroarch System/BIOS Dir.

2. More sensible continue message during Mame warning screen.

3. Enabled samples (now that the directories are generated/polled correctly), although may need further changes to work properly.

NOTE: Depends on https://github.com/libretro/RetroArch/commit/761ece0f3cabc769adfd3dcb14a7b3a3f4ecde70 