### PR TITLE
Remapped mame directories to retroarch directories.

### DIFF
--- a/README
+++ b/README
@@ -1,13 +1,19 @@
-Proof on concept
+Proof of concept
 Based on MAME 0.78
 
 Tested for OS X, linux, Wii, and Android (arm-v7a).
 
+Generates directories as it requires:
+* User-generated content: Saves (NVRAM, MEMCARD), Hi-Scores, and Controller Config files
+  are in sub-directories within /Retroarch Savefile Dir/mame2003/.
+* Everything else (Cheats, Mame INI, etc) in sub-directories within
+  /Retroarch System Dir/mame2003/.
+
 TODO:
 
-* Better path management. For now all games must be placed in a folder named 'rom'. Other folders must be created manually in 'rom's parent directory. Their names can be found under the File I/O section of src/libretro/osd.c.
 * Make sure all of the mkdir commands in makefile complete before any compiling starts.
-* Lots more
+* Input Descriptors (for use in Core Input Remapping).
+* Lots more.
 
 Notes:
 

--- a/src/libretro/osd.c
+++ b/src/libretro/osd.c
@@ -8,6 +8,7 @@
 #endif
 #include <sys/stat.h>
 #include <assert.h>
+#include <errno.h>
 
 #include "libretro.h"
 #include "osdepend.h"
@@ -19,8 +20,17 @@
 #include "driver.h"
 
 extern int16_t XsoundBuffer[2048];
+
 extern char* systemDir;
+extern char* saveDir;
 extern char* romDir;
+const char* parentDir = "mame2003"; /* groups mame dirs together to avoid conflicts in shared dirs */
+#if defined(_WIN32)
+char slash = '\\';
+#else
+char slash = '/';
+#endif
+
 extern retro_log_printf_t log_cb;
 
 #if defined(__CELLOS_LV2__) && !defined(__PSL1GHT__)
@@ -84,8 +94,35 @@ struct GameOptions
 };
 #endif
 
+int osd_create_directory(const char *dir)
+{
+    /* test to see if directory exists */
+    struct stat statbuf;
+    int err = stat(dir, &statbuf);
+    if(-1 == err) {
+        if(ENOENT == errno) {
+            /* does not exist */
+            log_cb(RETRO_LOG_WARN, "Directory %s not found - creating...\n", dir);
+            /* don't care if already exists) */
+            if (mkdir(dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0 && errno != EEXIST)
+            {
+                log_cb(RETRO_LOG_WARN, "Error creating directory %s ERRNO %d (%s)\n", dir, errno, strerror(errno));
+                return 0;
+            }
+        }
+    }
+    return 1;
+}
+
 int osd_init(void)
 {
+    /* ensure parent dir for various mame dirs is created */
+    char buffer[1024];
+    snprintf(buffer, 1024, "%s%c%s", saveDir, slash, parentDir);
+    osd_create_directory(buffer);
+    snprintf(buffer, 1024, "%s%c%s", systemDir, slash, parentDir);
+    osd_create_directory(buffer);
+    
     return 0;
 }
 
@@ -169,26 +206,36 @@ int osd_get_path_count(int pathtype)
 int osd_get_path_info(int pathtype, int pathindex, const char *filename)
 {
     char buffer[1024];
+    char currDir[1024];
     struct stat statbuf;
-#if defined(_WIN32)
-   char slash = '\\';
-#else
-   char slash = '/';
-#endif
 
     switch(pathtype)
     {
        case FILETYPE_ROM: /* ROM */
        case FILETYPE_IMAGE:
           /* removes the stupid restriction where we need to have roms in a 'rom' folder */
-          snprintf(buffer, 1024, "%s%c%s", romDir, slash, filename);
+          strcpy(currDir,romDir);
+          break;
+       case FILETYPE_IMAGE_DIFF:
+       case FILETYPE_NVRAM:
+       case FILETYPE_HIGHSCORE:
+       case FILETYPE_HIGHSCORE_DB:
+       case FILETYPE_CONFIG:
+       case FILETYPE_INPUTLOG:
+       case FILETYPE_MEMCARD:
+       case FILETYPE_SCREENSHOT:
+          /* user generated content goes in Retroarch save directory */
+          snprintf(currDir, 1024, "%s%c%s%c%s", saveDir, slash, parentDir, slash, paths[pathtype]);
           break;
        default:
-          snprintf(buffer, 1024, "%s%c%s%c%s", systemDir, slash, paths[pathtype], slash, filename);
+          /* additonal core content goes in Retroarch system directory */
+          snprintf(currDir, 1024, "%s%c%s%c%s", systemDir, slash, parentDir, slash, paths[pathtype]);
     }
+    
+    snprintf(buffer, 1024, "%s%c%s", currDir, slash, filename);
  
 #ifdef DEBUG_LOG
-    fprintf(stderr, "osd_get_path_info (buffer = [%s]), (systemDir: [%s]), (path type dir: [%s]), (path type: [%d]), (filename: [%s]) \n", buffer, systemDir, paths[pathtype], pathtype, filename);
+    fprintf(stderr, "osd_get_path_info (buffer = [%s]), (directory: [%s]), (path type dir: [%s]), (path type: [%d]), (filename: [%s]) \n", buffer, currDir, paths[pathtype], pathtype, filename);
 #endif
 
     if(stat(buffer, &statbuf) == 0)
@@ -200,36 +247,41 @@ int osd_get_path_info(int pathtype, int pathindex, const char *filename)
 osd_file *osd_fopen(int pathtype, int pathindex, const char *filename, const char *mode)
 {
    char buffer[1024];
+   char currDir[1024];
    osd_file *out;
-#if defined(_WIN32)
-   char slash = '\\';
-#else
-   char slash = '/';
-#endif
 
    switch(pathtype)
    {
       case 1: /* ROM */
+      case 2: /* IMAGE */
          /* removes the stupid restriction where we need to have roms in a 'rom' folder */
-         snprintf(buffer, 1024, "%s%c%s", romDir, slash, filename);
+         strcpy(currDir,romDir);
+         break;
+      case 3: /* IMAGE DIFF */
+      case 6: /* NVRAM */
+      case 7: /* HIGHSCORE */
+      case 8: /* HIGHSCORE DB */
+      case 9: /* CONFIG */
+      case 10: /* INPUT LOG */
+      case 11: /* MEMORY CARD */
+      case 12: /* SCREENSHOT */
+         /* user generated content goes in Retroarch save directory */
+         snprintf(currDir, 1024, "%s%c%s%c%s", saveDir, slash, parentDir, slash, paths[pathtype]);
          break;
       default:
-         snprintf(buffer, 1024, "%s%c%s%c%s", systemDir, slash, paths[pathtype], slash, filename);
+         /* additonal core content goes in Retroarch system directory */
+         snprintf(currDir, 1024, "%s%c%s%c%s", systemDir, slash, parentDir, slash, paths[pathtype]);
    }
+    
+   snprintf(buffer, 1024, "%s%c%s", currDir, slash, filename);
 
    if (log_cb)
-      log_cb(RETRO_LOG_INFO, "osd_fopen (buffer = [%s]), (systemDir: [%s]), (path type dir: [%s]), (path: [%d]), (filename: [%s]) \n", buffer, systemDir, paths[pathtype], pathtype, filename);
-
+      log_cb(RETRO_LOG_INFO, "osd_fopen (buffer = [%s]), (directory: [%s]), (path type dir: [%s]), (path type: [%d]), (filename: [%s]) \n", buffer, currDir, paths[pathtype], pathtype, filename);
+   
+   osd_create_directory(currDir);
+   
    out = (osd_file*)malloc(sizeof(osd_file));
-    
-   if (osd_get_path_info(pathtype, pathindex, filename) == PATH_NOT_FOUND)
-   {
-       /* if path not found, create */
-       char newPath[1024];
-       snprintf(newPath, sizeof(newPath), "%s%c%s", systemDir, slash, paths[pathtype]);
-       mkdir(newPath, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-   }
-    
+   
    out->file = fopen(buffer, mode);
 
    if(out->file == 0)

--- a/src/ui_text.c
+++ b/src/ui_text.c
@@ -92,7 +92,7 @@ static const char *mame_default_text[] =
 #endif
 	"The game has protection which isn't fully emulated.",
 	"There are working clones of this game. They are:",
-	"Type OK to continue",
+    "Type OK on Keyboard, or Left, Right on Joystick to continue",
 
 	/* main menu */
 	"Input (general)",


### PR DESCRIPTION
Second attempt - see https://github.com/libretro/mame2003-libretro/pull/20

1) Moved internal mame directories to:
- User-generated content: Saves (NVRAM, MEMCARD), Hi-Scores, and Controller Config files are in sub-directories within the Retroarch Savefile Dir.
- Everything else (Cheats, Mame INI, etc) in the Retroarch System/BIOS Dir.

Both sets of directories are within parent /mame2003/ directories, to avoid conflicts with other cores sharing the retroarch directories. e.g. /RetroarchSaveDir/mame2003/nvram/.
Directories will be automatically created if they don't exist.

2) More sensible continue message during Mame warning screen.

3) Enabled samples (now that the directories are generated/polled correctly). Samples are placed in /RetroArchSaveDir/mame2003/sample/gamename.zip

NOTE: Depends on https://github.com/libretro/RetroArch/commit/761ece0f3cabc769adfd3dcb14a7b3a3f4ecde70 