### PR TITLE
Added Raspberry Pi 3 platform & Optimistations, and 2 compilation fix…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,17 +116,19 @@ else ifeq ($(platform), rpi2)
    ENDIANNESS_DEFINES:=-DLSB_FIRST
    CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
    CPU_ARCH := arm
+   ARM = 1
 else ifeq ($(platform), rpi3)
    TARGET = $(TARGET_NAME)_libretro.so
    fpic = -fPIC
    CFLAGS += $(fpic)
    LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
    PLATCFLAGS += -Dstricmp=strcasecmp
-   PLATCFLAGS += -marm -mcpu=cortex-a53 -mfpu=neon-vfpv4 -mfloat-abi=hard -funsafe-math-optimizations
+   PLATCFLAGS += -marm -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -funsafe-math-optimizations
    PLATCFLAGS += -fomit-frame-pointer -ffast-math
    ENDIANNESS_DEFINES:=-DLSB_FIRST
    CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
    CPU_ARCH := arm
+   ARM = 1
 else ifeq ($(platform), android-armv7)
    TARGET = $(TARGET_NAME)_libretro_android.so
 


### PR DESCRIPTION
…es spotted by @joolswills

This resolves https://github.com/libretro/mame2003-libretro/issues/22

Note, to compile on the pi3 including these fixes/opts it's
`make platform=rpi3 ARM=1`
(or platform=rpi2)