### PR TITLE
Set aspect ratio to 0 (1:1) to avoid issues with vertically-oriented …

### DIFF
--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -161,7 +161,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
     info->geometry.base_height = height;
     info->geometry.max_width = width;
     info->geometry.max_height = height;
-    info->geometry.aspect_ratio = (float)videoConfig.aspect_x / (float)videoConfig.aspect_y;
+    info->geometry.aspect_ratio = 0;
     info->timing.fps = Machine->drv->frames_per_second;
     info->timing.sample_rate = 48000.0;
 }


### PR DESCRIPTION
…games appearing fullscreen incorrectly.

Same fix as https://github.com/libretro/mame2010-libretro/commit/99e5998c65641a6e4cecc258298a54a4cd676d35

You can see an example of the issue here: http://blog.petrockblock.com/forums/topic/vertical-games-stretched-to-full-screen-pacman-194x-etc

AFAIK the core shouldn't care about the retroarch aspect ratio option anyway, as all of that stuff is handled by libretro anyway.