### PR TITLE
Mouse/trackball & analog joystick support (and a samples regression fix)

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -194,4 +194,9 @@ int input_ui_pressed_repeat(int code, int speed);
 int is_joystick_axis_code(unsigned code);
 int return_os_joycode(InputCode code);
 
+#define LIBRETRO_ANALOG_MIN -32768
+#define LIBRETRO_ANALOG_MAX 32767
+#define ANALOG_MIN -128
+#define ANALOG_MAX 128
+
 #endif

--- a/src/libretro/joystick.c
+++ b/src/libretro/joystick.c
@@ -11,23 +11,24 @@
 ******************************************************************************/
 
 #define EMIT_RETRO_PAD(INDEX) \
-    {"RetroPad" #INDEX " Left", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_LEFT, JOYCODE_##INDEX##_LEFT}, \
-    {"RetroPad" #INDEX " Right", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_RIGHT, JOYCODE_##INDEX##_RIGHT}, \
-    {"RetroPad" #INDEX " Up", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_UP, JOYCODE_##INDEX##_UP}, \
-    {"RetroPad" #INDEX " Down", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_DOWN, JOYCODE_##INDEX##_DOWN}, \
-    {"RetroPad" #INDEX " B", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_B, JOYCODE_##INDEX##_BUTTON1}, \
-    {"RetroPad" #INDEX " Y", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_Y, JOYCODE_##INDEX##_BUTTON2}, \
-    {"RetroPad" #INDEX " X", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_X, JOYCODE_##INDEX##_BUTTON3}, \
-    {"RetroPad" #INDEX " A", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_A, JOYCODE_##INDEX##_BUTTON4}, \
-    {"RetroPad" #INDEX " L", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_L, JOYCODE_##INDEX##_BUTTON5}, \
-    {"RetroPad" #INDEX " R", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_R, JOYCODE_##INDEX##_BUTTON6}, \
-    {"RetroPad" #INDEX " L2", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_L2, JOYCODE_##INDEX##_BUTTON7}, \
-    {"RetroPad" #INDEX " R2", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_R2, JOYCODE_##INDEX##_BUTTON8}, \
-    {"RetroPad" #INDEX " L3", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_L3, JOYCODE_##INDEX##_BUTTON9}, \
-    {"RetroPad" #INDEX " R3", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_R3, JOYCODE_##INDEX##_BUTTON10}, \
-    {"RetroPad" #INDEX " Start", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_START, JOYCODE_##INDEX##_START}, \
-    {"RetroPad" #INDEX " Select", ((INDEX - 1) * 16) + RETRO_DEVICE_ID_JOYPAD_SELECT, JOYCODE_##INDEX##_SELECT}
-
+    {"RetroPad" #INDEX " Left", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_LEFT, JOYCODE_##INDEX##_LEFT}, \
+    {"RetroPad" #INDEX " Right", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_RIGHT, JOYCODE_##INDEX##_RIGHT}, \
+    {"RetroPad" #INDEX " Up", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_UP, JOYCODE_##INDEX##_UP}, \
+    {"RetroPad" #INDEX " Down", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_DOWN, JOYCODE_##INDEX##_DOWN}, \
+    {"RetroPad" #INDEX " B", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_B, JOYCODE_##INDEX##_BUTTON1}, \
+    {"RetroPad" #INDEX " Y", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_Y, JOYCODE_##INDEX##_BUTTON2}, \
+    {"RetroPad" #INDEX " X", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_X, JOYCODE_##INDEX##_BUTTON3}, \
+    {"RetroPad" #INDEX " A", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_A, JOYCODE_##INDEX##_BUTTON4}, \
+    {"RetroPad" #INDEX " L", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_L, JOYCODE_##INDEX##_BUTTON5}, \
+    {"RetroPad" #INDEX " R", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_R, JOYCODE_##INDEX##_BUTTON6}, \
+    {"RetroPad" #INDEX " L2", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_L2, JOYCODE_##INDEX##_BUTTON7}, \
+    {"RetroPad" #INDEX " R2", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_R2, JOYCODE_##INDEX##_BUTTON8}, \
+    {"RetroPad" #INDEX " L3", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_L3, JOYCODE_##INDEX##_BUTTON9}, \
+    {"RetroPad" #INDEX " R3", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_R3, JOYCODE_##INDEX##_BUTTON10}, \
+    {"RetroPad" #INDEX " Start", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_START, JOYCODE_##INDEX##_START}, \
+    {"RetroPad" #INDEX " Select", ((INDEX - 1) * 18) + RETRO_DEVICE_ID_JOYPAD_SELECT, JOYCODE_##INDEX##_SELECT}, \
+    {"RetroMouse" #INDEX " Left Click", ((INDEX - 1) * 18) + 16, JOYCODE_MOUSE_##INDEX##_BUTTON1}, \
+    {"RetroMouse" #INDEX " Right Click", ((INDEX - 1) * 18) + 17, JOYCODE_MOUSE_##INDEX##_BUTTON2}
 
 struct JoystickInfo jsItems[] =
 {
@@ -44,7 +45,9 @@ struct JoystickInfo jsItems[] =
 
 ******************************************************************************/
 
-int retroJsState[64];
+int retroJsState[72];
+int16_t mouse_x;
+int16_t mouse_y;
 
 const struct JoystickInfo *osd_get_joy_list(void)
 {
@@ -68,7 +71,8 @@ void osd_lightgun_read(int player, int *deltax, int *deltay)
 
 void osd_trak_read(int player, int *deltax, int *deltay)
 {
-
+    *deltax = mouse_x;
+    *deltay = mouse_y;
 }
 
 void osd_analogjoy_read(int player,int analog_axis[MAX_ANALOG_AXES], InputCode analogjoy_input[MAX_ANALOG_AXES])

--- a/src/libretro/joystick.c
+++ b/src/libretro/joystick.c
@@ -46,8 +46,9 @@ struct JoystickInfo jsItems[] =
 ******************************************************************************/
 
 int retroJsState[72];
-int16_t mouse_x;
-int16_t mouse_y;
+int16_t mouse_x[4];
+int16_t mouse_y[4];
+int16_t analogjoy[4][4];
 
 const struct JoystickInfo *osd_get_joy_list(void)
 {
@@ -71,13 +72,29 @@ void osd_lightgun_read(int player, int *deltax, int *deltay)
 
 void osd_trak_read(int player, int *deltax, int *deltay)
 {
-    *deltax = mouse_x;
-    *deltay = mouse_y;
+    *deltax = mouse_x[player];
+    *deltay = mouse_y[player];
+}
+
+int convert_analog_scale(int input)
+{
+    static int libretro_analog_range = LIBRETRO_ANALOG_MAX - LIBRETRO_ANALOG_MIN;
+    static int analog_range = ANALOG_MAX - ANALOG_MIN;
+
+    return (input - LIBRETRO_ANALOG_MIN)*analog_range / libretro_analog_range + ANALOG_MIN;
 }
 
 void osd_analogjoy_read(int player,int analog_axis[MAX_ANALOG_AXES], InputCode analogjoy_input[MAX_ANALOG_AXES])
 {
+    int i;
+    for (i = 0; i < MAX_ANALOG_AXES; i ++)
+    {
+        if (analogjoy[player][i])
+            analog_axis[i] = convert_analog_scale(analogjoy[player][i]);
+    }
 
+    analogjoy_input[0] = IPT_AD_STICK_X;
+    analogjoy_input[1] = IPT_AD_STICK_Y;
 }
 
 void osd_customize_inputport_defaults(struct ipd *defaults)

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -226,7 +226,10 @@ static void update_variables(void)
    }
    else
       skip_warnings = 0;
-   
+
+   var.value = NULL;
+   var.key = "mame2003-samples";
+
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || var.value)
    {
       if(strcmp(var.value, "enabled") == 0)
@@ -235,7 +238,7 @@ static void update_variables(void)
          samples = 0;
    }
    else
-      cheats = 0;
+      samples = 0;
    
    var.value = NULL;
    var.key = "mame2003-sample_rate";

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -129,8 +129,10 @@ static int driverIndex; //< Index of mame game loaded
 extern const struct KeyboardInfo retroKeys[];
 extern int retroKeyState[512];
 extern int retroJsState[72];
-extern int16_t mouse_x;
-extern int16_t mouse_y;
+
+extern int16_t mouse_x[4];
+extern int16_t mouse_y[4];
+extern int16_t analogjoy[4][4];
 extern struct osd_create_params videoConfig;
 
 unsigned retroColorMode;
@@ -313,7 +315,7 @@ void retro_run (void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       update_variables();
 
-   // Keyboard
+   /* Keyboard */
    thisInput = retroKeys;
    while(thisInput->name)
    {
@@ -321,12 +323,14 @@ void retro_run (void)
       thisInput ++;
    }
 
-   // Joystick
    jsState = retroJsState;
    for (i = 0; i < 4; i ++)
    {
-      for (j = 0; j < 16; j ++)
-         *jsState++ = input_cb(i, RETRO_DEVICE_JOYPAD, 0, j);
+      /* Joystick */
+       for (j = 0; j < 16; j ++) {
+          *jsState++ = input_cb(i, RETRO_DEVICE_JOYPAD, 0, j);
+       }
+       
 
       /* Mouse
        * Currently libretro only supports 1 mouse, so port is hard-coded.
@@ -339,12 +343,19 @@ void retro_run (void)
          mouse_x[i] = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
          mouse_y[i] = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
       }
+      else
+      {
+         *jsState++ = 0;
+         *jsState++ = 0;
+      }
+
+      /* Analog joystick */
+      analogjoy[i][0] = input_cb(i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X);
+      analogjoy[i][1] = input_cb(i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y);
+      //analogjoy[i][2] = input_cb(i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
+      //analogjoy[i][3] = input_cb(i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
    }
-    
-   // Mouse
-   mouse_x = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
-   mouse_y = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
-    
+
    mame_frame();
 
    audio_batch_cb(XsoundBuffer, Machine->sample_rate / Machine->drv->frames_per_second);

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -128,8 +128,9 @@ static int driverIndex; //< Index of mame game loaded
 
 extern const struct KeyboardInfo retroKeys[];
 extern int retroKeyState[512];
-
-extern int retroJsState[64];
+extern int retroJsState[72];
+extern int16_t mouse_x;
+extern int16_t mouse_y;
 extern struct osd_create_params videoConfig;
 
 unsigned retroColorMode;
@@ -305,12 +306,12 @@ void retro_run (void)
    int i, j;
    int *jsState;
    const struct KeyboardInfo *thisInput;
-	bool updated = false;
+   bool updated = false;
 
    poll_cb();
 
-	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
-		update_variables();
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
+      update_variables();
 
    // Keyboard
    thisInput = retroKeys;
@@ -326,8 +327,24 @@ void retro_run (void)
    {
       for (j = 0; j < 16; j ++)
          *jsState++ = input_cb(i, RETRO_DEVICE_JOYPAD, 0, j);
-   }
 
+      /* Mouse
+       * Currently libretro only supports 1 mouse, so port is hard-coded.
+       * MAME seems to support 4 mice/trackballs, so could be changed
+       * in the future. */
+      if (i == 0)
+      {
+         *jsState++ = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
+         *jsState++ = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
+         mouse_x[i] = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
+         mouse_y[i] = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
+      }
+   }
+    
+   // Mouse
+   mouse_x = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
+   mouse_y = input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
+    
    mame_frame();
 
    audio_batch_cb(XsoundBuffer, Machine->sample_rate / Machine->drv->frames_per_second);


### PR DESCRIPTION
This adds:

- mouse/trackball support (tested with centipede). only supports 1 mouse - seems like libretro only permits one mouse device as it was giving the same output regardless of port.
- analog joystick support (tested with afterburner). only one analog stick (Left) as that's all mame supports.

...and fixes a samples regression with a previous change (whoops!).