### PR TITLE
Support to share one mouse-type device as 2 dial controls (player 1 =…

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -46,6 +46,7 @@ extern unsigned int coinlockedout[COIN_COUNTERS];
 static unsigned short input_port_value[MAX_INPUT_PORTS];
 static unsigned short input_vblank[MAX_INPUT_PORTS];
 
+extern unsigned int dial_share_xy;
 
 
 /***************************************************************************
@@ -2073,6 +2074,13 @@ void update_analog_port(int port)
 	delta = 0;
 
 	player = IP_GET_PLAYER(in);
+    
+    /* if second player on a dial, and dial sharing turned on, use Y axis from player 1 */
+    if (dial_share_xy && type == IPT_DIAL && player == 1)
+    {
+        axis = Y_AXIS;
+        player = 0;
+    }
 
 	delta = mouse_delta_axis[player][axis];
 

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -53,6 +53,7 @@ void retro_set_environment(retro_environment_t cb)
       { "mame2003-samples", "Samples; enabled|disabled" },
       { "mame2003-sample_rate", "Sample Rate (KHz); 48000|8000|11025|22050|44100" },
       { "mame2003-cheats", "Cheats; disabled|enabled" },
+      { "mame2003-dialsharexy", "Share 2 player dial controls across one X/Y device; disabled|enabled" },
       { NULL, NULL },
    };
    environ_cb = cb;
@@ -180,6 +181,7 @@ unsigned skip_disclaimer = 0;
 unsigned skip_warnings = 0;
 unsigned samples = 0;
 unsigned cheats = 0;
+unsigned dial_share_xy = 0;
 
 static void update_variables(void)
 {
@@ -265,6 +267,19 @@ static void update_variables(void)
    }
    else
       cheats = 0;
+
+    var.value = NULL;
+    var.key = "mame2003-dialsharexy";
+    
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || var.value)
+    {
+        if(strcmp(var.value, "enabled") == 0)
+            dial_share_xy = 1;
+        else
+            dial_share_xy = 0;
+    }
+    else
+        dial_share_xy = 0;
 }
 
 static void check_system_specs(void)


### PR DESCRIPTION
… X axis, player 2 = Y axis).

Fixes https://github.com/libretro/mame2003-libretro/issues/48