### PR TITLE
fix arch,otherwise fails if ARCH is set beforehand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,10 +281,10 @@ ifdef SYMBOLS
 
 # O3 optimisation causes issues on ARM
 else ifeq ($(ARM), 1)
-   CFLAGS += -DNDEBUG $(ARCH) -O2 -fomit-frame-pointer -fstrict-aliasing
+   CFLAGS += -DNDEBUG $(arch) -O2 -fomit-frame-pointer -fstrict-aliasing
 
 else
-   CFLAGS += -DNDEBUG $(ARCH) -O3 -fomit-frame-pointer -fstrict-aliasing
+   CFLAGS += -DNDEBUG $(arch) -O3 -fomit-frame-pointer -fstrict-aliasing
 endif
 
 # extra options needed *only* for the osd files


### PR DESCRIPTION
I have ARCH set for pbuilder, which I can workaround, but it seems ARCH defined here for ARM optimizations should be "arch", given it's usage above and throughout the makefile. I also  had success just unsetting ARCH, with : `ARCH :=` in the Makefile. 