### PR TITLE
Reverts previous aspect ratio fix and adds rotation correction. Now b…

### DIFF
--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -171,7 +171,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
     info->geometry.base_height = height;
     info->geometry.max_width = width;
     info->geometry.max_height = height;
-    info->geometry.aspect_ratio = 0;
+    info->geometry.aspect_ratio = rotated ? (float)videoConfig.aspect_y / (float)videoConfig.aspect_x : (float)videoConfig.aspect_x / (float)videoConfig.aspect_y;
     info->timing.fps = Machine->drv->frames_per_second;
     info->timing.sample_rate = sample_rate;
 }


### PR DESCRIPTION
…oth horizontal and vertical games are in the correct DAR.

Previous fix: https://github.com/libretro/mame2003-libretro/pull/25

Tested with:
blasteroids (was stretched horizontally post https://github.com/libretro/mame2003-libretro/pull/25)
pacman (was stretched horizontally pre https://github.com/libretro/mame2003-libretro/pull/25)
sfa3 (was stretched horizontally post https://github.com/libretro/mame2003-libretro/pull/25)

all working fine now :)