### PR TITLE
Removed $(ARCH) as it isn't set by the makefile, and causes problems …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,10 +288,10 @@ ifdef SYMBOLS
 
 # O3 optimisation causes issues on ARM
 else ifeq ($(ARM), 1)
-   CFLAGS += -DNDEBUG $(ARCH) -O2 -fomit-frame-pointer -fstrict-aliasing
+   CFLAGS += -DNDEBUG -O2 -fomit-frame-pointer -fstrict-aliasing
 
 else
-   CFLAGS += -DNDEBUG $(ARCH) -O3 -fomit-frame-pointer -fstrict-aliasing
+   CFLAGS += -DNDEBUG -O3 -fomit-frame-pointer -fstrict-aliasing
 endif
 
 # extra options needed *only* for the osd files


### PR DESCRIPTION
…with the buildbot, which seems to occasionally set it to things that aren't compile flags.

Fixes issues like http://hastebin.com/ajazofutac