### PR TITLE
add highscore.dat

### DIFF
--- a/metadata/highscore.dat
+++ b/metadata/highscore.dat
@@ -1,0 +1,14322 @@
+;     ___   ___ ___ ________ ______  ________ _____     _______    ______   _______ __________
+;    /  /  /  //  //       //  ___/ / ____  // _   \   /      /   / __   \ / __   //___   ___/
+;   /  /__/  //  //  _____//  /    / /   / // /_/  /  /  ____/   / /  \  // /_/  /    /  /
+;  /  __    //  //____   //  /    / /   / //      /  /  ____/   / /   / // __   /    /  /  
+; /  /  /  //  //       //  /___ / /___/ //  /\  \  /      /_  / /___/ // /  / /    /  / 
+;/__/  /__//__//_______//______//_______//__/  \__\/______//_//_______//_/  /_/    /__/               
+;_________________________________________________________________________________________
+
+;This file can be edited with a text editor, but keep the same format:
+; all fields are separated by a colon (:)
+; <gamename>:
+; <cpu>:<address>:<length>:<value to wait for 
+; in the first byte/word>:<value to wait for in the last byte/word>
+; [repeat the above as many times as necessary]
+;
+; *** All Entries Without Name Done By Me !! ( Leezer ) ;0) leezer@leezer.karoo.co.uk ***
+;
+; contact firebrand at :- firebrand75@hotmail.com
+; Unofficial hiscore.dat file official website :- http://highscore.mameworld.info/
+; This hiscore.dat is for use with mame version 0.133u1 and newer builds (aug 15th 09)
+; Mameplus also supports hiscore.dat :- http://mameicons.free.fr/mame32p/
+
+;***************************************************************************
+;*    latest unofficial highscore_v_infinity additions below - by leezer   *
+;*            hiscore.dat discontinued as from mame v0.107u2.              *
+;*                 [ for Leezer's personal use only ]                      * 
+;* (to use this .dat file after the release of mame v0.107u2 you must use) *
+;*          (a hacked mame that enables hiscore.dat saves.)                *
+;***************************************************************************
+
+metlfrzr:
+0:d822:a0:00:37
+
+pacmanblb:
+0:4688:3:00:00
+0:5180:1:40:40
+0:51a0:1:40:40
+0:51c0:1:40:40
+0:51e0:1:40:40
+0:5200:1:40:40
+0:5220:1:40:40
+0:466f:1:03:03
+
+;lockonph:        ;***** needs work !! ******
+;0:ffe459:87:03:00
+;0:ffe44a:1:04:04
+
+knockout:
+mariner:
+scrambles:
+triplep:
+triplepa:
+800fath:
+strfbomb:
+scramb2:  ;******Scramble (bootleg)
+knockoutb:
+knockoutc:
+0:4200:1e:00:01
+0:40a8:03:00:01
+
+fball:
+0:d840:69:00:48
+
+wingforc:
+0:30d7e7:13f:00:35
+
+strider: ;*Missing: Stage completion information (Player name + Score)
+striderj: 
+stridrjr: 
+striderua:
+strideruc:
+0:ff89aa:78:ff:20
+0:ff0ca4:04:00:00
+;*DOES NOT WORK: Stage completion information (Player name + Score)
+;*0:920000:14:00:00 Address pointers
+;*0:921004:08:00:00 Stage: St. Petersburg
+;*0:921804:08:00:00 Stage: Siberian Wilderness
+;*0:922004:08:00:00 Stage: Adventure In Amazon
+;*0:922804:08:00:00 Stage: The Arial Battleship
+;*0:923004:08:00:00 Stage: <secret>
+
+ikari:
+ikarijp:
+ikarijpb:
+ikarinc:  ;******ikari warriors (us no continues)
+ikaria:  ;******ikari warriors (us)
+0:ff0b:50:00:49
+0:fc5f:3:00:00
+
+ikariram:
+0:ff0b:50:00:4f
+0:fc5f:3:00:00
+
+piratesb:
+pirates:
+0:10a544:76:4e:10
+0:10a5b0:1:4e:4e
+
+;********mexico86.c
+mexico86:
+kicknrun:
+kicknrunu:
+mexico86a:
+0:ee18:2d:17:49
+
+anteatergg:
+0:40ef:3c:00:20
+
+anteaterg:
+0:4ef:3c:00:20
+
+;******The Anteater (UK)
+anteateruk:
+0:4ef:3c:00:59
+
+;********scobra.c
+anteater:
+0:80ef:3c:01:4c
+
+sf2v004:
+0:ffd276:30:01:20
+0:ffd2c6:18:ff:9e
+0:ffd2ee:04:01:67
+
+taotaido:
+0:fe91e4:4e:14:02
+
+taotaidoa:
+0:fe9340:4e:01:02
+
+taotaido3:
+0:fe91d4:4e:01:02
+
+;(sdi - strategic defence initiative)
+sdi:
+defense:  ;******Defense (System 16B, FD1089A 317-0028) 
+sdibl:
+sdib:
+sdibl2:
+sdibl3:
+sdibl4:
+sdibl5:
+sdibl6:
+0:fff800:320:00:20
+0:fffb88:4:00:00
+0:fffbca:3:4b:5a 
+
+;*******Twin Cobra 2 (World) & (us)
+tcobra2:
+tcobra2u:
+0:4006e0:11c:00:00
+0:4007d3:1:02:02
+0:400845:1:80:80
+
+ktiger2:
+0:4006e0:11e:00:00
+0:4007f9:1:01:01
+
+;********tmnt.c
+blswhstl:
+detatwin:
+blswhstla:
+0:207000:50:00:2e
+0:204048:4:00:30
+
+;********tecmo.c
+gemini:
+0:cf41:46:00:00
+0:c026:3:00:00
+0:c027:1:50:50
+0:d241:1:40:40
+0:d221:1:40:40
+0:d201:1:35:35
+0:d1e1:1:30:30
+0:d1c1:1:30:30
+0:d1a1:1:30:30
+0:d181:1:30:30
+
+;******Crypt Killer (konamigq.c) (by GreatStone)
+cryptklr:
+0:237dc0:50:40:00
+
+;********taito_f3.c
+akkanvdr:
+spcinv95:
+spcinv95u:
+0:417484:6c:00:00
+0:4174e7:1:55:55
+0:410b82:4:00:00
+
+edf:
+edfu:  ;******E.D.F. : Earth Defense Force (North America)
+edfbl:
+edfa:
+0:64c17:107:01:00
+0:61d3e:4:00:00
+0:64ccb:1:09:09
+
+;********warpwarp.c
+warpwarp:
+0:831d:3:00:00
+
+warpwarpr:
+warpwarpr2:
+0:831d:3:00:00
+0:8358:1e:00:18
+
+;*********mcr3.c (turbo)
+;** highscore updates after first game **
+turbo:
+turboa:
+turbobc:
+turbob:
+turbobl:
+turbod:
+0:e400:1e:94:94
+0:f310:1e:00:00
+0:f292:d:0f:f0
+
+; fenix is not working yet ;[Special thanks to Cananas for enhancing this entry]
+phoenix:
+condor:
+falcon:
+nextfase:
+phoenix3:
+phoenixa:
+phoenixb:
+phoenixc:
+phoenixc2:
+phoenixj: 
+phoenixt:
+vautour:
+pleiads:
+pleiadbl:
+pleiadce:
+phoenixc3:
+phoenixc4:
+pleiadsb2:
+phoenixs:
+avefenix:
+pleiadsi:
+pleiadss:
+phoenixdal:
+avefenixrf:
+avefenixl:
+phoenixass:
+vautourza:
+pleiadsn:
+0:4389:03:00:00
+0:41e1:01:20:20
+0:41c1:01:20:20
+0:41a1:01:20:20
+0:4181:01:20:20
+0:4161:01:20:20
+0:4141:01:20:20
+0:4381:03:00:00
+0:4301:01:20:20
+0:42e1:01:20:20
+0:42c1:01:20:20
+0:42a1:01:20:20
+0:4281:01:20:20
+0:4261:01:20:20
+0:4385:03:00:00
+0:40c1:01:20:20
+0:40a1:01:20:20
+0:4081:01:20:20
+0:4061:01:20:20
+0:4041:01:20:20
+0:4021:01:20:20
+
+batman2:
+0:4289:03:00:00
+0:51e1:01:20:20
+0:51c1:01:20:20
+0:51a1:01:20:20
+0:5181:01:20:20
+0:5161:01:20:20
+0:5141:01:20:20
+0:4281:03:00:00
+0:5301:01:20:20
+0:52e1:01:20:20
+0:52c1:01:20:20
+0:52a1:01:20:20
+0:5281:01:20:20
+0:5261:01:20:20
+0:4285:03:00:00
+0:50c1:01:20:20
+0:50a1:01:20:20
+0:5081:01:20:20
+0:5061:01:20:20
+0:5041:01:20:20
+0:5021:01:20:20
+
+mmagic:
+0:2000:3:00:00
+
+;*******maya & inca
+maya:
+inca:
+mayaa:
+mayac:
+0:7500:22:41:00
+0:7741:2:fa:00
+
+;******paradise
+paradise:
+paradisea:
+paradisee:
+0:e6c3:3:00:01
+0:e6e3:22:41:00
+
+vigilant:
+vigilantbl:
+vigilantc:
+vigilantd: ;[Clone added by Wob]
+vigilanto: ;[Clone added by Wob]
+vigilantg:
+vigilantb:
+vigilanta:
+0:e048:3f:00:48
+
+dfkbl:
+0:ca02028:2fcb:08:56
+
+mcheonru:
+0:1090dc:11f:00:06
+
+;********(daioh)
+daioh:
+daioha:
+0:10748c:a3:00:05
+0:10748f:1:e8:e8
+
+daiohc:
+0:207496:99:00:05
+
+daiohp:
+0:206c96:99:00:05
+
+carhntds:
+0:845e:6:00:04
+0:83a1:6:00:00
+
+;********berzerk.c
+berzerk: 
+berzerk1:
+berzerkg:
+berzerks:
+berzerkf:
+0:4302:3c:00:00
+0:4301:1:42:42
+
+gprider:
+gprideru:
+gpriderj:
+gpriderjs:
+gpriders:
+gpriderus:
+0:280192:aa:34:30
+0:9c708:8:01:20
+
+spider:
+0:6f6c:13:50:00
+0:e07c:2c:41:00
+0:e542:b:01:01
+0:6f7d:1:27:27
+
+cdracula:
+0:c39f:6a:43:00
+0:c406:1:13:13
+0:cc2b:4:50:00
+
+brickzn:
+brickznv4:
+brickznv5:
+brickzn11:
+0:cf10:4e:23:4d
+0:c8a0:2:00:03
+
+smissw:
+0:c025b6:63:30:20
+
+;*******(sidearms & clones)
+sidearms:
+sidearmsr:
+sidearmsur1:
+0:e682:4e:00:03
+0:e601:7:00:00
+0:e6ce:1:3b:3b
+
+sidearmsu:
+0:e682:4e:00:03
+0:e601:7:00:00
+0:e6ce:1:01:01
+
+sidearmsj:
+0:e682:4e:00:00
+0:e601:7:00:00
+0:e6ce:1:3b:3b
+
+xmultiplm72:
+0:8099e:43:50:00
+0:80998:06:00:00
+
+xmultipl:
+0:9c998:4:00:00
+0:9c99d:44:00:00
+0:9c9da:1:62:62
+
+startrks:
+0:d78a:5:30:30
+
+;******black widow
+bwidow:
+0:302:24:20:db
+0:326:76:1b:11
+
+bwidowp:
+0:32b:31:00:00
+
+supduck:
+0:ffc332:30:41:00
+0:ffc360:1:10:10
+
+;********Dragon World II (ver. 110X, Export)
+drgw2:
+dw2v100x:
+0:80caf8:46:49:40
+
+drgw2hk:
+0:80f13a:46:49:40
+
+alinvade:
+0:9f:3:00:00
+
+hachamf:
+hachamfb:
+0:fc000:3f0:01:4e
+
+nzeroteam:
+0:925c:4b:40:55
+
+zerotm2k:
+0:924e:4b:40:55
+
+zeroteam:
+zeroteamd:
+zeroteamc:
+zeroteams:
+zeroteamsr:
+zeroteama:
+zeroteamb:
+0:9212:4b:40:55
+
+raidendx:
+raidendxu:
+raidendxk:
+raidendxj:
+raidendxa2:
+raidendxa1:
+raidendxnl:
+raidendxg:
+raidendxch:
+raidendxja:
+0:a25a:2cf:a0:2a
+
+r2dx_v33_r2:
+0:9e46:ef:50:2a
+
+r2dx_v33:
+0:a2d8:2cf:a0:2a
+
+raiden2:
+raiden2dx:
+raiden2nl:
+raiden2hk:
+raiden2i:
+raiden2j:
+raiden2u:
+raiden2sw:
+raiden2f:
+0:9dd4:ef:50:2a
+
+raiden2g:
+raiden2ea:
+raiden2e:
+raiden2eua:
+raiden2eu:
+0:9de4:ef:50:2a
+
+arescue:
+arescuej:
+0:20fb00:9f:a0:49
+
+fixeightbl:
+fixeight:
+fixeightt:
+fixeighth:
+fixeightht:
+fixeightj: 
+fixeightjt:
+fixeighta: 
+fixeightat:
+fixeightk:
+fixeightkt:
+fixeighttw:
+fixeighttwt:
+fixeightu:
+fixeightut:
+0:100408:4:00:00
+0:10043c:82:00:04
+0:10040a:1:53:53
+
+airass:
+firebarr:
+0:e3252:8c:00:20
+
+;********cosmic cop(world)(by Firebrand)
+cosmccop:
+0:e3c5e:6e:10:41
+0:e3d72:03:10:06
+0:e3d18:3c:00:5a
+
+gallop:
+0:a3d00:6e:10:41
+0:a3e14:03:10:06
+0:a3dba:3c:00:5a
+
+bchopper:
+mrheli:
+0:a37c0:78:63:60
+0:a37ba:03:63:01
+
+;********kangaroo.c
+kangaroo:
+kangarooa:
+kangaroob:
+0:e1a0:3c:00:00
+0:e1da:1:50:50
+
+nemesis: 
+nemesisuk: 
+0:06509a:1:76:76
+0:065010:8c:00:00
+0:060098:4:00:00
+0:06009a:1:73:73
+
+wyvernf0:
+0:8800:190:00:26
+
+rolcrush:
+0:fede76:76:41:01
+
+;********alpha68k.c
+gangwarsu:
+gangwarsb:
+gangwars:
+gangwarsj:
+0:43bb2:34:00:45
+
+;spec2k:  ;***** not working yet
+;0:c0301:3b:0f:98
+;0:c033a:1:3a:3a
+
+;(dai toride) (by GeoMan)
+daitorid:
+0:8042ba:28:00:40  
+0:8042e2:28:02:00
+
+daitorida:  ;******Daitoride (YMF278B version)
+0:f042ba:4a:00:01
+
+;** after you get a hiscore, you must start a new game then exit **
+;** for save to work (i.e make sure the new top score is displaying in top score spot) **
+griffon:
+0:4389:3:00:00
+0:41e0:1:20:20
+0:41c0:1:20:20
+0:41a0:1:20:20
+0:4180:1:20:20
+0:4160:1:20:20
+0:4140:1:20:20
+
+falconz:
+vautourz:
+0:4389:03:00:00
+0:41e0:01:20:20
+0:41c0:01:20:20
+0:41a0:01:20:20
+0:4180:01:20:20
+0:4160:01:20:20
+0:4140:01:20:20
+0:4381:03:00:00
+0:4300:01:20:20
+0:42e0:01:20:20
+0:42c0:01:20:20
+0:42a0:01:20:20
+0:4280:01:20:20
+0:4260:01:20:20
+0:4385:03:00:00
+0:40c0:01:20:20
+0:40a0:01:20:20
+0:4080:01:20:20
+0:4060:01:20:20
+0:4040:01:20:20
+0:4020:01:20:20
+
+phoenxp2:
+0:4289:03:00:00
+0:51e1:01:20:20
+0:51c1:01:20:20
+0:51a1:01:20:20
+0:5181:01:20:20
+0:5161:01:20:20
+0:5141:01:20:20
+
+;*******(passing shot (2 players)(bootleg))
+passshtb:
+passsht:
+passht4b:
+passshtj:
+passsht16a:
+passshta:
+passshtad:
+passshtd:
+passshtjd:
+0:ffee00:59e:4d:41
+
+cencourt:
+0:ffec00:59e:4d:41
+
+bombsa:  ;not working yet ??
+d84c:3c:17:00
+
+;(super toffy) (by GeoMan)
+stoffyu:
+stoffy:
+0:833:e0:00:f2
+0:913:f0:20:00
+
+;** you must let the highscore display in attract mode before starting a game  ** 
+shangha3u:
+shangha3j:
+0:307be2:78:00:1d
+
+shangha3:
+0:307be4:78:00:1d
+
+megaphx:
+0:c54:9f:1f:30
+
+intrepid:
+intrepid2:
+intrepidb:
+0:803c:3d:02:fd
+0:8035:2:00:00
+
+intrepidb2:
+intrepidb3:
+0:803c:3d:02:fd
+0:8035:2:00:00
+
+galaxia:
+galaxiaa:
+galaxiab:
+galaxiac:
+0:1d1d:3:00:00
+0:1c91:1:55:55
+
+funkyjeta:
+funkyjetj:  ;******Funky Jet (Japan)
+funkyjet:
+0:143a01:20:00:10
+0:143a21:140:12:00
+
+discoboy:
+discoboyp:
+0:f800:80:00:2e
+
+ddpdfk:
+0:c889b1c:2cff:06:4e
+
+ddpdfk10:
+0:c88877c:2cff:06:4e
+
+espgal2:
+0:c43e064:ed:00:4d
+
+futari10:
+0:c51c0b0:18d:00:48
+
+futari15:
+0:c51f7a4:1dd:00:41
+
+futari15a:
+0:c51f794:1dd:00:41
+
+futaribl:
+futariblj:
+0:c5193ac:275:00:44
+
+mushisam:
+0:c244d8c:ed:00:4d
+
+mushisama:
+0:c244d1c:ed:00:4d
+
+mushisamb:
+0:c244dec:9d:00:4e
+
+deathsml:
+0:c53abd8:63f:00:4d
+
+dsmbl:
+0:c89aee9:95e:00:4d
+
+danceyesj:
+0:2b5350:30:a0:48
+
+danceyes:
+0:2b5830:30:a0:48
+
+blockcar:
+blockcarb:
+0:f00058:54:00:08
+
+sokyugrt:
+0:608dc30:9d:82:47
+0:60bda38:4:00:c0
+
+krzybowl:
+0:800105:63:00:00
+0:c00080:1:05:05
+
+wivernwg:
+0:c79fb:f9:24:40
+
+earthjkr:
+earthjkrp:
+0:103204:2f:00:42
+
+;********(4 en raya)
+4enraya:
+0:c152:6c:01:0c
+
+4enrayaa:
+0:c13e:6c:01:0c
+
+;********segar.c (astro blaster (version 2 & 3))
+astrob:
+astrob2:
+0:cb3f:F6:00:00
+0:CC18:1:5C:5C
+
+;******Astro Blaster (version 2a)
+astrob2a:
+astrobg:
+astrob1:
+0:cb3f:da:00:5c
+
+strider2:
+strider2a:
+shiryu2:
+0:4dfe08:a8:01:24
+
+aquarush:
+0:f4f68:136:4a:bb
+0:f5468:3cef:4a:02
+
+;********taito_f2.c (growl (us))
+growl:
+growla:
+runark:
+growlu:
+0:10e340:f9:01:43
+
+growlp:
+0:10d724:28:09:45
+
+ertictac:
+0:bb1c:2e:46:ca
+
+ertictacb:
+ertictaca:
+0:b184:2e:46:c1
+
+dolmen:
+0:f0602:4c:4e:53
+
+carket:
+0:120e79:2e:00:41
+
+tekken2jc:
+0:359dd8:10f:3f:4e
+
+tekken2ab:
+tekken2ub:
+tekken2jb:
+0:35a504:10f:3f:4e
+
+tekken2:
+0:354bd4:10f:3f:4e
+
+tekken2aa:
+0:352cb8:10f:3f:4e
+
+tekken:
+0:1e0458:1bf:01:53
+
+tekkenac:
+0:1e0498:17f:04:4b
+
+tekkenab:
+0:1e0148:17f:04:45
+
+tekkenjb:
+0:1e0148:17f:04:4e
+
+pipedrm:
+pipedrmj:
+pipedrmu:
+pipedrmt:
+0:8d80:59:0c:00
+
+;********galpanic.c (new fantasia)
+newfant:
+newfanta:
+0:c825b7:62:30:20
+
+ikari3:
+ikari3u:  
+ikari3j:
+ikari3k:
+0:4007e:58:00:1d
+
+cosmicgi:   ;****** fixed ******
+cosmicg:
+0:3C10:04:00:00
+0:2d5d:01:00:00
+0:2d7d:01:00:00
+0:2d9d:01:00:00
+0:2dbd:01:00:00
+0:2ddd:01:00:00
+0:2e5d:01:00:00
+0:2e7d:01:00:00
+0:2e9d:01:00:00
+0:2ebd:01:00:00
+0:2edd:01:00:00
+0:2f5d:01:00:00
+0:2f7d:01:00:00
+0:2f9d:01:00:00
+0:2fad:01:00:00
+0:2fbd:01:00:00
+0:2fdd:01:00:00
+0:305d:01:00:00
+0:307d:01:00:00
+0:309d:01:00:00
+0:30bd:01:00:00
+0:30dd:01:00:00
+0:315d:01:00:00
+0:317d:01:00:00
+0:319d:01:00:00
+0:31bd:01:00:00
+0:31dd:01:00:00
+0:325d:01:7c:7c
+0:327d:01:82:82
+0:329d:01:82:82
+0:32bd:01:82:82
+0:32dd:01:7c:7c
+
+bublbob2p:
+0:406848:04:00:34
+
+rvschool:  ;****** rival school & clones do not save top scores team logo ******
+rvschoola:
+rvschoolu:
+jgakuen:
+0:1f6524:48:50:0f
+
+seabattl:
+0:1c0b:15:00:0a
+
+arcadian:
+0:1fe601:5b:01:2a
+
+desertdn:
+0:82c7:3:00:00
+0:82c8:1:50:50
+
+tetristh:
+0:1051a4:64:45:08
+
+twrldc94:
+0:ffe5e3:58:47:0d
+
+;********wc90 fixed !!  ********
+wc90:
+wc90b:
+wc90b2:
+wc90t:
+wc90a:
+wc90b1:
+wc90ba:
+0:800f:1e:00:00
+0:804d:01:11:11
+
+teddybb:
+teddybbo:
+teddybbobl:
+0:c578:3:00:00
+0:ef03:31:00:49
+
+;(satan of saturn) and clones (by GeoMan)
+satansat: 
+zarzon:
+satansata:
+satansatind:
+0:24:2:00:05
+
+misncrft:
+0:76fd4:60:46:10
+
+misncrfta:
+0:7f290:60:46:10
+
+guttangt:
+0:4700:78:00:3e
+0:41c6:3:00:01
+
+locomotn:
+locoboot:  ;******Loco-Motion (bootleg)
+cottong:
+gutangtn:
+0:9f00:78:00:3e
+0:99c6:3:00:01
+
+caractn:
+caractn2:
+0:0500:f:01:82
+0:0640:f:42:53
+0:000a:3:12:01
+
+attackfc:
+0:2080:60:00:24
+0:2047:2:00:00
+
+timefgtr:
+0:8535:1b:00:00
+0:854d:1:10:10
+
+stuntair:  ;****** hiscore updated when you start a game  ******
+0:c13d:3c:00:5b
+0:fa41:01:a0:a0
+0:fa21:01:b4:b4
+0:fa01:01:b0:b0
+0:f9e1:01:b0:b0
+0:f9c1:01:b0:b0
+0:f9a1:01:b0:b0
+
+;********silkroad.c (the legend of silkroad)
+silkroad:
+silkroada:
+0:fe305e:8c:4d:01
+
+;*******(power spikes (world))
+pspikes:
+spikes91:
+pspikesb:
+svolly91:
+spikes91b:
+pspikesba:
+0:1023f1:4d:00:03
+
+pspikesc:
+pspikesk:
+0:1023f1:4d:00:07
+
+pspikesu:
+0:1023f1:4d:00:06
+
+indianbt:  ;******Indian Battle
+indianbtbr:
+0:2314:2:00:00
+
+ccbootmr:
+0:8083:54:02:52
+0:808f:1:02:02
+
+bagman: ;[Special thanks to Cananas for enhancing this entry]
+bagmanmc:
+bagnard:
+bagnarda:
+bagmans:
+bagmans2:
+sbagman:
+sbagmans:
+bagmanf:
+bagmanm2:
+bagnardi:
+0:6217:50:00:10
+
+;** top score updates as soon as a game is started **
+snowbros:
+snowbrosj:
+snowbrosa:
+snowbrosb:
+snowbrosc:
+snowbrosd:
+wintbob:
+snowbros3:
+snowbro3:
+ballboy:
+snowbroswb:
+toto:
+0:1001ca:40:00:4f
+0:1014ad:1:1f:1f
+0:1014b7:1:1f:1f
+0:1014c1:1:08:08
+0:1014cb:1:04:04
+0:1014d5:1:04:04
+0:1014df:1:04:04
+0:1014e9:1:04:04
+
+popobear:
+0:210c42:27c:00:01
+
+;mp_sonic:  ;*** not working **
+;0:a02723:4e:00:5a
+;0:fefe0f:1:65:65
+
+ghostmun:
+0:4288:3:00:00
+0:5180:1:40:40
+0:51a0:1:40:40
+0:51c0:1:40:40
+0:51e0:1:40:40
+0:5200:1:40:40
+0:5220:1:40:40
+0:4087:1:01:01
+
+sranger:  
+srangero:
+srangern:
+srangerw:
+rranger:
+0:d220:4c:00:20
+0:c851:2:00:03
+
+srangerb:
+0:d220:4c:00:2e
+0:c851:2:00:03
+
+pprobe:
+0:f380:45:00:15
+0:cd9e:1:00:00
+0:cdbe:1:00:00
+0:cdde:1:03:03
+0:cdfe:1:01:01
+0:ce1e:1:01:01
+0:ce3e:1:01:01
+0:ce5e:1:01:01
+
+sparkman:
+sparkmana:
+0:c930:6a:00:01
+0:c880:2:00:03
+
+cadanglr:
+0:4c0:19:18:00
+0:4d7:1:50:50
+0:61:2:00:00
+
+starfigh:
+0:db30:26:00:4c
+0:c8d0:2:00:03
+
+littlerb:
+0:20202e:9f:11:30
+0:20203d:1:e8:e8
+
+gng:
+gnga:
+gngt:
+makaimur:
+makaimurc:
+makaimurg:
+gngbl:  
+gngblita:
+gngc:
+0:1518:5a:15:72
+0:00d0:4:00:00
+
+gngprot:
+0:1508:5a:15:72
+0:00d0:4:00:00
+
+panicr:  ;******panic road
+panicrg:
+0:18fc:95:40:20
+
+skydest:
+0:b801:6c:4b:00
+0:b86b:1:10:10
+
+;*******Jumping Pop
+jumppop:
+jumppope:
+0:123c10:a0:45:50
+0:123c01:3:00:00
+
+dbza:
+0:48665c:54:00:1e
+0:4863f2:4:00:00
+
+dbz:
+0:486660:54:00:1e
+0:4863f2:4:00:00
+
+cfishing:
+0:4c0:18:18:50
+
+flipjack:
+0:6500:f0:00:4f
+0:6061:6:00:00
+
+;********decocass.c (cassette: burger time)
+cbtime:
+0:33:24:00:12
+
+chamburger:
+0:32:24:00:12
+
+;********spacefb.c (space firebird (nintendo & gremlin & bootleg))
+;** top score don`t update until you lose your first life, pretty **
+;** lame way for doing a hiscore - but who am i to complain!! ;0) **
+spacefb:
+spacefbb:
+spacefbe:
+spacefbu:
+spacefbe2:
+starwarr:
+0:c0a0:1e:00:00
+0:c0e0:3:00:00
+0:c773:6:05:05
+0:9a51:6:05:05
+
+spacefbg:
+0:c0a0:2b:00:00
+0:c3c0:1e:11:10
+0:c0e0:3:00:30
+
+spacefba:
+0:c773:6:05:05
+0:9a51:6:05:05
+0:c0e0:3:00:00
+
+;********rastan.c
+rastan: ;[Special thanks to Wob for enhancing this entry]
+rastanu:
+rastanu2:
+rastsaga:
+rastsaga1:
+rastan2:
+rastanua:
+rastanub:
+rastsagaa:
+0:10c140:26:31:4e
+0:d000b2:1:00:00
+0:d000b5:1:2b:2b
+0:d000ba:1:00:00
+0:d000bd:1:2d:2d
+0:d000c2:1:00:00
+0:d000c5:1:31:31
+0:d000ca:1:00:00
+0:d000cd:1:2c:2c
+0:d000d2:1:01:01
+0:d000d5:1:2a:2a
+0:d000da:1:01:01
+0:d000dd:1:2a:2a
+
+;*******Knights of the Round (world 911127 & clones))
+knights:
+knightsj: 
+knightsu: 
+knightsb:
+knightsja:
+0:ffe53a:257:00:00
+0:ffe78f:1:05:05
+0:ffe7ca:1:02:02
+0:ffa4b6:4:00:00
+
+kong:
+0:827f:19:10:00
+0:8296:1:46:46
+
+fantastc:
+0:82af:1b:d0:07
+
+forgottn:
+lostwrld:
+forgottnu:
+lostwrldo:
+forgottnua:
+forgottnu1:
+forgottnuaa:
+forgottna:
+0:ffe142:50:00:20
+0:ffb2a0:04:00:00
+
+noahsark:
+0:2801:1e:81:44
+
+itaten:
+0:a266:1e:56:4b
+0:a02c:1:54:54
+
+brapboys:  ;hiscore broken in game  brapboys games ??
+brapboysj:
+brapboysu:
+0:1030c5:31:00:4a
+
+birdiy:   
+0:4c29:1e:00:00
+0:c3ed:6:30:20
+0:4d03:3:00:00
+
+fspiderb:
+0:8066:45:00:19
+
+candy:  ;** you must wait untill hiscore table has displayed before starting a game  **
+0:40025660:f0:41:02
+
+;penky:   ;  **  needs work !! **
+;0:e687:23:4f:04
+;0:e187:03:01:01
+
+landgear:
+0:8036f8c:ea:01:4a
+
+raidersr3:
+raiders:
+0:1c08:40:00:00
+0:1c21:1:31:31
+0:1c0e:1:00:00
+
+xevi3dg:
+0:1512b8:3b:48:4b
+
+superwng:
+0:7920:c8:00:19
+
+galactic:
+spacmiss:
+0:20a8:3:00:00
+
+bublpong: 
+0:e64c:32:00:13
+0:e64d:1:30:30
+0:e5df:1:00:00
+0:e5e0:1:00:00
+0:e5e4:1:00:00
+0:e5e6:1:00:00
+0:e5e1:1:00:00
+0:e5e2:1:00:00
+0:e5e3:1:00:00
+0:e5e7:1:00:00
+0:e5e8:1:00:00
+0:e5e9:1:00:00
+0:e5ea:1:00:00
+0:e5eb:1:00:00
+0:e5f6:1:00:00
+0:e5f7:1:00:00
+0:e5ee:1:00:00
+0:e5ef:1:00:00
+0:e5f0:1:00:00
+0:e5ec:1:00:00
+0:e5ed:1:00:00
+0:e5f3:1:00:00
+0:e5f4:1:00:00
+0:e5d9:1:00:00
+0:e5da:1:00:00
+0:f457:1:00:00
+0:f458:1:00:00
+0:e601:1:00:00
+0:e602:1:00:00
+0:e600:1:00:00
+0:e5ff:1:00:00
+0:e5fd:1:00:00
+0:e5fc:1:00:00
+0:e5fb:1:00:00
+0:e5fa:1:00:00
+0:e5f9:1:00:00
+0:e5f8:1:00:00
+0:e5fe:1:00:00
+0:e604:1:00:00
+0:e605:1:00:00
+0:e606:1:00:00
+0:e607:1:00:00
+0:e609:1:00:00
+0:e60a:1:00:00
+0:e611:1:00:00
+0:e60b:2:00:00
+
+sbomber:
+0:600c904:64:00:00
+0:600c95d:1:01:01
+
+sbombera:
+0:600c900:64:00:00
+0:600c959:1:01:01
+
+espgal:
+espgalbl:
+0:80107e:80:00:00
+0:8010f5:1:30:30
+
+ddpdoj:
+ddpdoja:
+ddpdojb:
+0:80381a:8c:00:02
+
+ddpdojblkbl:
+0:803824:8c:01:06
+
+;dodonpachi dai-ou-jou (black label)  -- new version game is the default hiscore.dat version !! 
+ddpdojblk:  ;**** you choose between old/new game on startup swap the ; on the version you want. ****
+ddpdojblka:
+0:803824:8c:01:06   ;*** new version (default) - if you use other version you must delete .hi file
+;0:803824:8c:00:02   ;*** old version - if you use other version you must delete .hi file
+
+ket:
+keta:
+ketb:
+ketbl:
+0:80101c:80:00:00
+0:801093:1:30:30
+
+;********karnov.c
+karnov:
+karnovj:
+karnova:
+0:06000A:04:00:00
+0:063C00:28:00:00
+0:063D00:28:00:4A
+
+hvyunit:
+hvyunito:
+hvyunitu:
+hvyunitj:
+0:e190:28:00:50
+
+rumba:  ;****** not working - mame 040u3 debug prob ???
+0:e18a:3:40:01
+0:c37c:1:20:20
+0:c3bc:1:31:31
+0:c3fc:1:32:32
+0:c43c:1:33:33
+0:c47c:1:34:34
+0:c4bc:1:30:30
+0:e005:1:5d:5d
+
+skykiddx:
+skykiddxo:
+0:5000:45:00:2f
+0:5001:1:03:03
+
+bygone:  ;***** GAME NOT 100% working yet !! *****
+0:e0c0:3c:00:47
+0:e076:6:00:00
+0:e002:1:0a:0a
+0:f42d:6:3c:3c
+
+pzlbreak:  
+0:102d9c:32:50:32
+0:102e0b:3:00:00
+
+berenstn:
+0:28:1e:81:4f
+
+orunners:
+orunnersu:
+orunnersj:
+0:20e301:3b:53:75
+0:20e212:1:78:78
+
+hotshock:
+hotshockb:
+0:40a8:3:00:05
+0:4200:1e:0a:02
+
+mrdig:
+0:13d29e:145e:41:50
+0:13e6e8:1:57:57
+
+msgogo:
+0:f032d6:47:00:0e
+
+unclepoo:
+0:9447:5a:00:43
+
+fantjour:
+fantjoura:
+0:c0d336:4:00:00
+0:c0d342:78:00:09
+0:c0d338:1:73:73
+
+polepos2:
+0:3000:7f2:d0:a2
+0:40d6:1:c9:c9
+
+;********polepos.c (pole position 2)
+polepos2b:
+polepos2a:
+poleps2c:
+poleps2a:
+0:3000:7f2:d0:a2
+
+;********polepos.c (pole position)
+polepos1:
+poleposa:
+poleposa1:
+poleposa2:
+0:3000:7f2:b0:95
+0:4080:1:56:56
+
+sub:
+0:b727:5a:24:24
+
+milliped:
+millipdd:
+0:85:f:05:17
+0:6d:f:20:04
+0:24:1:a0:a0
+
+woodpeck:
+woodpeca:
+0:4e88:3:00:00
+0:43ed:6:40:40
+0:4dda:1:03:03
+
+;**** this saves victorys top 10 todays scores (nvram takes care of the rest)
+victory:
+victorba:
+0:f01a:46:56:00
+0:f05b:1:54:54
+
+vmetal:
+vmetaln:
+0:ff000e:53:00:49
+
+vhunt2:
+vhunt2r1:
+vhunt2d:
+0:fff426:ad:00:02
+
+tnextspc:
+tnextspc2:
+0:72b40:4f:00:4b
+0:70016:4:00:00
+
+tnextspcj:
+0:72b40:4f:00:43
+0:70016:4:00:00
+
+kodr1:
+kod:
+0:ff9d94:28:01:04
+
+kodu:
+kodj:
+kodja:
+kodb:
+0:ff9d94:28:00:04
+
+tharrier:
+tharrierj:
+0:f9100:80:00:4e
+
+ssf2mdb:
+0:fffcb3:29:00:20
+
+spidman:
+spidmanu:
+spidmanj:
+0:208c00:7f:a0:57
+
+;** hiscore & top score don`t update until you lose your first life, pretty **
+;** lame way for doing a hiscore - but who am i to complain!! ;0)            **
+spacebrd:
+0:c0e0:3:00:00
+0:d0e0:3:00:00
+0:e0e0:3:00:00
+0:f0f0:3:00:00
+0:be51:6:05:05
+0:bd51:6:88:60
+
+;********(soldier girl amazon)
+amazon:
+amatelas:
+0:40db4:46:00:0e
+0:40d66:4:00:00
+0:40d68:1:50:50
+
+shogwarr:
+fjbuster:
+shogwarru:
+shogwarrk:
+0:106664:27:00:4b
+
+nmouse:
+nmouseb:
+0:4e88:3:00:00
+0:c3ed:7:40:40
+0:4dce:1:07:07
+
+mrjong:
+0:8401:98:00:09
+0:a013:6:00:00
+
+blkbustr:
+crazyblk:
+0:8401:a9:00:0a
+0:a013:6:00:00
+
+getstar:
+getstarj:
+gtstarb1:
+gtstarb2:
+0:c0d2:48:00:00
+0:c110:1:0a:0a
+0:c0ca:1:17:17
+
+galsnew:
+galsnewa:
+galsnewj:
+galsnewk:
+0:c825b6:64:30:31
+
+destryer:
+0:20e5:2:ff:ff
+
+blockgal:
+blockgalb:
+0:c062:3:00:01
+
+bgaregga:
+bgareggahk:
+bgareggatw:
+0:10ca4d:ea:0f:2a
+0:100030:1:72:72
+
+bgaregganv:
+bgareggacn:
+bgareggat2:
+0:10ca4f:ea:0f:2a
+0:100030:1:72:72
+
+bgareggabl:
+bgareggabla:
+0:10ca4d:446:0f:3f
+
+bwings:
+0:0d:3:00:04
+0:d00:8c:34:20
+
+bwingsa:
+bwingso:
+0:0d:3:00:04
+0:d00:f0:34:20
+
+azurian:
+0:40b3:3:00:00
+0:40b4:1:50:50
+
+attckufo:
+0:ca:2:00:00
+0:2e3:1:a0:a0
+0:2fa:1:a0:a0
+0:311:1:a0:a0
+0:328:1:a0:a0
+
+altair:
+0:30e5:2:00:00
+0:3008:1:58:58
+
+sundance: ;[Special thanks to Cananas for creating this entry]
+0:0151:01:12:12
+0:014e:02:00:00
+
+qb3: ;[Special thanks to Cananas for creating this entry]
+0:01a1:01:11:11
+0:01a0:32:00:00
+
+skylove:  ;******Sky Love
+0:414b:3:00:00
+0:297d:2:0f:fc
+0:299d:2:0f:fc
+0:29bd:2:0c:0c
+0:29dd:2:0c:0c
+0:29fd:2:0c:0c
+0:2a1d:2:0f:fc
+0:2a3d:2:0f:fc
+0:2a9d:2:0f:fc
+0:2abd:2:0f:fc
+0:2add:2:0c:0c
+0:2afd:2:0c:0c
+0:2b1d:2:0c:0c
+0:2b3d:2:0f:fc
+0:2b5d:2:0f:fc
+0:2bbd:2:0f:fc
+0:2bdd:2:0f:fc
+0:2bfd:2:0c:0c
+0:2c1d:2:0c:0c
+0:2c3d:2:0c:0c
+0:2c5d:2:0f:fc
+0:2c7d:2:0f:fc
+0:2cdd:2:0f:fc
+0:2cfd:2:0f:fc
+0:2d1d:2:0c:0c
+0:2d3d:2:0c:0c
+0:2d5d:2:0c:0c
+0:2d7d:2:0f:fc
+0:2d9d:2:0f:fc
+0:2dfd:2:0f:fc
+0:2e1d:2:0f:fc
+0:2e3d:2:0c:0c
+0:2e5d:2:0c:0c
+0:2e7d:2:0c:0c
+0:2e9d:2:0f:fc
+0:2ebd:2:0f:fc
+
+phpython:  ;******Python (Photon System)
+0:4e1c:3:00:00
+0:4e1d:1:05:05
+
+dland:  ;******dream land/super dream land
+0:e654:23:00:4f
+0:e67b:3:1f:13
+0:e64c:3:00:00
+0:e5df:1:00:00
+0:e5e0:1:00:00
+0:e5e4:1:00:00
+0:e5e6:1:00:00
+0:e5e1:1:00:00
+0:e5e2:1:00:00
+0:e5e3:1:00:00
+0:e5e7:1:00:00
+0:e5e8:1:00:00
+0:e5e9:1:00:00
+0:e5ea:1:00:00
+0:e5eb:1:00:00
+0:e5f6:1:00:00
+0:e5f7:1:00:00
+0:e5ee:1:00:00
+0:e5ef:1:00:00
+0:e5f0:1:00:00
+0:e5ec:1:00:00
+0:e5ed:1:00:00
+0:e5f3:1:00:00
+0:e5f4:1:00:00
+0:e5d9:1:00:00
+0:e5da:1:00:00
+0:f457:1:00:00
+0:f458:1:00:00
+0:e601:1:00:00
+0:e602:1:00:00
+0:e600:1:00:00
+0:e5ff:1:00:00
+0:e5fd:1:00:00
+0:e5fc:1:00:00
+0:e5fb:1:00:00
+0:e5fa:1:00:00
+0:e5f9:1:00:00
+0:e5f8:1:00:00
+0:e5fe:1:00:00
+0:e604:1:00:00
+0:e605:1:00:00
+0:e606:1:00:00
+0:e607:1:00:00
+0:e609:1:00:00
+0:e60a:1:00:00
+0:e611:1:00:00
+0:e60b:2:00:00
+
+holeland:  ;******Hole Land (by Jose Juan Iglesias)
+0:86c7:18:00:11
+0:86d0:3:00:03
+
+holeland2:
+0:86cb:18:00:11
+0:86d4:3:00:03
+
+;*******steelwkr
+steelwkr:
+0:200a:06:00:00
+
+mirax:  ;******mirax
+0:d01c:6:00:00
+0:d028:2d:00:29
+
+miraxa:
+0:d02d:2d:00:29
+0:d021:6:00:00
+
+balonfgt: ;[Special thanks to Cananas for creating this entry]
+0:6100:1e:00:00
+0:6124:0f:0a:10
+
+bayroute:
+bayrouteb2:
+bayrouteb1:  ;******Bay Route (encrypted, protected bootleg)
+bayroute1:
+bayroutej:
+bayrouted:
+bayroutejd:
+0:500110:50:00:0f
+
+tsamurai:
+tsamurai2:
+nunchaku:
+yamagchi:
+tsamuraih:  ;******Samurai Nihon-ichi (set 3, harder)
+ladymstr:
+0:c060:1e:00:00
+0:c080:1e:11:11
+0:c026:3:00:00
+
+hatris:
+hatrisj:  ;******hatris (japan)
+0:8d01:77:42:00
+0:8d76:01:10:10
+
+xevious:
+sxevious:
+sxeviousj:  ;******Super Xevious (Japan) 
+xevios: 
+xeviousa:
+battles: 
+0:8510:4d:00:24
+0:8024:3:00:00
+0:8025:1:40:40
+
+xeviousb:
+xeviousc:
+0:8510:46:00:14
+0:8024:3:00:00
+0:8025:1:40:40
+
+sci:
+scia:  
+scij:  
+sciu:  
+0:101500:28:02:51
+0:10164e:4:02:80
+
+scin:  ;******Special Criminal Investigation (Negro Torino hack)
+0:101500:28:00:4e
+0:10164e:4:00:60
+
+lkage:
+lkageoo:  ;******The Legend of Kage (oldest)
+lkageb:
+lkageb2:
+lkageb3:
+lkageo:
+0:e25f:85:00:52
+0:e188:3:00:00
+
+fstarfrc:
+fstarfrcj:  ;******Final Star Force (Japan)
+0:101272:80:00:00
+0:1000a9:3:00:a0
+
+ckongpt2:
+ckongpt2a:
+ckongpt2jeu:
+ckongo:
+monkeyd:
+ckongpt2b:
+ckongalc:
+ckongs:
+ckongg:
+kkgalax:  
+ckongpt2j:  ;******Crazy Kong Part II (Japan)
+ckong:
+ckongmc:
+dking:
+ckonggx:
+ckongdks:
+0:6100:AA:94:92
+0:60b8:3:50:00
+
+cabalbl:
+cabalbl2:  ;******Cabal (bootleg of Joystick version, set 2)
+cabal:
+cabalus2:
+cabalus:
+cabala:
+cabaluk:
+0:42167:63:44:00
+
+aliens:
+aliensa:  ;******Aliens (Asia)
+aliensj:
+aliensu:
+aliens2:
+aliens3:  
+aliensj2:  
+0:1e30:38:00:48
+
+asterix:
+asterixj:
+asterixeac:
+asterixeaa:
+asterixaad:
+0:107800:50:00:01
+
+spctbird:  ;******space thunderbird
+0:8042:54:00:24
+0:804f:1:50:50
+
+pbobble2:
+0:40a858:112:00:00
+0:400152:2:01:a2
+
+pbobble2j:
+pbobble2o:
+pbobble2u:
+0:40a854:112:00:00
+0:400152:2:01:a2
+
+jmpbreak:
+0:95098:5f:00:67
+
+spuzbobl:
+0:28bf08:10d:20:01
+
+pzletime:  ;******Puzzle Time (Prototype)
+0:f03804:3b:00:4e
+
+prmrsocr:
+prmrsocrj:
+0:100364:4c:59:40
+
+suprheli:  ;******Super Heli (Super Cobra bootleg)
+0:80a8:3:00:01
+0:8200:1e:00:01
+
+masterw:
+masterwu:  
+masterwj:  ;******Master of Weapon (Japan)
+yukiwo:
+0:2030c0:28:00:4f
+
+aoh:  ;******Age Of Heroes - Silkroad 2 (v0.63 - 2001/02/07)
+0:28e784:f8:4b:01
+
+batrider:
+batriderc:
+batriderja:
+batriderk:
+batrideru:
+batriderj:
+batridert:
+batriderhk:
+0:20fa20:310:00:30
+
+mrdrillrj: ;******Mr Driller [Special thanks to Cananas for finding the table]
+mrdrillr:
+0:201038:288:76:76
+
+sfiii3:  ;******street fighter III 3rd strike: fight for the future (usa, 990608)
+sfiii3u:
+sfiii3nr1:  ;******street fighter III 3rd strike: fight for the future (japan, 990512 no cd)
+sfiii3n:  ;******street fighter III 3rd strike: fight for the future (japan, 990608 no cd)
+sfiii3r1:
+sfiii3ur1:
+0:2016e4c:18d:1c:04
+
+sfiii2:  ;******street fighter III 2nd impact: giant attack (asia, 970930, no cd)
+sfiii2n:  ;******street fighter III 2nd impact: giant attack (usa, 970930)
+0:2015924:90:1c:02
+
+sfiiina:  ;******street fighter III: New Generation (asia, 970204 no cd)
+sfiii:  ;******street fighter III: New Generation (usa, 970204)
+sfiiij:
+sfiiiu:
+sfiiia:
+sfiiin:
+0:201381c:90:1c:02
+
+vamphalf:  ;******Vamf x1/2 (Europe)
+0:5afdc:3a:00:03
+
+vamphalfk:  ;******Vamf x1/2 (korea)
+0:5ae6c:3a:00:03
+
+turbosba:  ;******Turbo Sub (prototype rev. TSC6)
+0:3c7a:46:00:56
+
+stratvox:
+stratvxb:
+speakres:
+spacecho2:  ;******space echo (set 1)
+spacecho:  ;******space echo (set 2)
+speakresb:
+0:4001:3:00:00
+0:4010:3:00:00
+
+rtype:
+rtypeu:
+rtypeb:  ;******R-Type (World bootleg)
+rtypej:
+0:42f4e:71:45:20
+
+rtypejp:
+0:42f4a:71:45:20
+
+rtypem82b:
+0:d2f51:6e:00:20
+
+dkong:
+dkongjo:
+dkongj:
+dkongjpo:
+dkongo:
+dkongjo1:
+dkongf:  ;******Donkey Kong Foundry (hack)
+dkonghrd:
+dkongpe:
+0:6100:AA:94:76
+0:60B8:03:50:00
+0:7641:01:00:00
+0:7621:01:00:00
+0:7601:01:07:07
+0:75e1:01:06:06
+0:75c1:01:05:05
+0:75a1:01:00:00
+
+dogyuun:
+dogyuuna:  ;******Dogyuun (Licensed to Unite Trading For Korea)
+0:10034a:7c:00:1b
+
+dogyuunt:
+0:10034a:7c:01:1b
+
+centipdb:
+centiped2:
+centiped3:
+centiped:
+centtime:
+centipdd:  ;******Centipede Dux (hack)
+0:000b:0f:10:01
+0:0023:0f:04:12
+
+magworm:
+0:0002:30:52:1a
+
+millpac:
+0:0002:2a:90:17
+
+jjsquawk:
+jjsquawkb:  ;******J. J. Squawkers (bootleg)
+jjsquawkb2:
+jjsquawko:
+0:20561e:4f:00:61
+
+blktiger:
+blktigerb1:
+blktigerb2:  ;******Black Tiger (bootleg set 2)
+blktigera:
+blktigerb3:
+0:e200:50:00:20
+0:e1e0:8:00:00
+
+ssf2t:
+ssf2tu:
+ssf2ta:
+ssf2xj:
+ssf2tur1:
+ssf2xjd:
+ssf2xjr:
+ssf2tad:
+ssf2th:
+0:ffd6a2:30:00:20
+0:ffd71a:4:00:00
+
+ssf2j:
+ssf2jr1:
+ssf2jr2:
+ssf2:
+ssf2r1:
+ssf2u:
+ssf2a:
+ssf2ar1:
+ssf2ud:
+ssf2tbj:
+ssf2tbr1:
+ssf2tbd:
+ssf2tb:
+0:ffd5a2:30:00:20
+0:ffd61a:4:00:00
+
+spf2t:
+spf2tu:
+spf2xj:
+spf2xjd:
+spf2ta:
+spf2th:
+spf2td:
+0:ffd7aa:4e:00:02
+0:ff8081:1:01:01
+
+sgemf:
+pfghtj:
+sgemfa:
+sgemfd:
+sgemfh:
+0:fff23a:2:00:02
+0:fff23c:ae:00:00
+
+sfa2:
+sfa2u:
+sfa2ur1:
+sfz2ad:
+sfz2a:
+sfz2br1:
+sfz2b:
+sfz2ald:
+sfz2h:
+sfz2j:
+sfz2jr1:
+sfz2n:
+sfz2aad:
+sfz2al:
+sfz2alb:
+sfz2alh:
+sfz2alj:
+sfz2jd:
+0:ffdf6a:ad:00:01
+
+sfa:
+sfzjr1:
+sfzj:
+sfau:  
+sfar3:
+sfar2:
+sfar1:
+sfad:
+sfza:
+sfzar1:
+sfzbr1:
+sfzb:
+sfzjr2:
+sfzhr1:
+sfzh:
+0:ffaea0:9f:01:16
+
+sfa3:
+sfa3r1:
+sfz3j:
+sfz3jr1:
+sfz3a:
+sfz3jr2:  
+sfa3b:
+sfa3ur1:
+sfa3ud:  ;******Street Fighter Alpha 3 (USA 980904 Phoenix Edition) (bootleg)
+sfa3u:
+sfz3ar1:
+sfa3hr1:
+sfa3h:
+sfz3jr2d:
+0:ff23be:ae0:00:05
+
+sfa3us:
+0:ff23b6:ae0:00:05
+
+sf2ceuc:
+sf2ceua:
+sf2rb2:
+sf2ceea:
+sf2ceub:  
+sf2cejb:  
+sf2rb:   
+sf2hfu:
+sf2hfj:
+sf2m2:
+sf2m1: 
+sf2m4: 
+sf2m5:
+sf2m6:
+sf2m7:
+sf2mdt:
+sf2rb3:
+sf2koryu:
+sf2yyc:
+sf2acc:
+sf2acca:
+sf2dkot2:
+sf2ce:
+sf2ceja:
+sf2cejc:
+sf2amf:
+sf2m8:
+sf2mdta:
+sf2dongb:
+sf2bhh:
+sf2amf2:
+sf2ceblp:
+sf2mdtb:
+sf2m9:
+sf2mdtc:
+sf2cebltw:
+sf2m10:
+0:ffd276:28:00:20
+0:ffd2c6:14:ff:96
+0:ffd2ee:04:00:00
+
+xmvsf:
+xmvsfur1:
+xmvsfu:  
+xmvsfar1:
+xmvsfa:
+xmvsfb:
+xmvsfr1:
+xmvsfh:
+xmvsfjr2:
+xmvsfjr1:
+xmvsfjr3:
+xmvsfj:
+xmvsfu1d:  ;******X-Men Vs. Street Fighter (USA 961004 Phoenix Edition) (bootleg)
+xmvsfar2:
+xmvsfar3:
+xmvsfur2:
+0:ff256e:63:00:05
+
+xmcotar1: 
+xmcotaj2:
+xmcotaar1:
+xmcotar1d:  ;******X-Men: Children of the Atom (Euro 950105 Phoenix Edition)
+xmcotah:
+xmcotajr:
+xmcotaj3:
+xmcotaj1:
+xmcotau:
+xmcotaj:
+xmcotahr1:
+xmcota:
+xmcotaa:
+0:ffec8e:3c:00:01
+
+vsav:
+vsava:
+vsavu:
+vsavd:  ;******Vampire Savior: The Lord of Vampire (Euro 970519 Phoenix Edition) (bootleg)
+vsavh:
+vsavj:
+0:fff426:ad:00:02
+
+viostorm:
+viostormu:
+viostorma:
+viostormj:
+viostormub:
+viostormab:
+viostormeb:
+0:20dc00:139:00:07
+0:200138:8:00:45
+
+progear:
+progearj:
+progeara:
+progearjd:  ;******Progear no Arashi (Japan 010117 Phoenix Edition) (bootleg) 
+progearud:
+progearjbl:  
+0:ff3dcf:e5:20:04
+
+nwarr:
+nwarrb:
+nwarrh:
+nwarru:
+nwarrud:  ;******Night Warriors: Darkstalkers' Revenge (USA 950406 Phoenix Edition) (bootleg)
+vhuntj:
+vhuntjr1:
+nwarra:
+vhuntjr2:
+vhuntjr1s:
+0:fff4e8:4:00:01
+0:fff4ec:44:00:00
+
+mvsc:
+mvscb:
+mvscj:
+mvscjr1:
+mvsca:
+mvscr1:  
+mvsch:  
+mvscu:
+mvscar1:
+mvscud:  ;******Marvel Vs. Capcom: Clash of Super Heroes (USA 980123 Phoenix Edition) (bootleg)  
+mvscur1:
+mvscjsing:
+0:ff26fd:66:ff:00
+
+skatekds:  ;******Vs. Skate Kids. (Graphic hack of Super Mario Bros.)
+0:7d7:6:00:00
+0:7d8:1:02:02
+0:6675:8a:05:05
+
+msh:
+mshu:
+msha:
+mshb:
+mshh:
+mshjr1:
+mshj:
+mshud:  ;******Marvel Super Heroes (US 951024 Phoenix Edition) (bootleg)
+0:ff2720:9f:00:0b
+
+megaman2:
+megaman2a:
+megamn2d:  ;******Mega Man 2: The Power Fighters (USA 960708 Phoenix Edition) (bootleg)
+0:ffefc0:118:00:02
+0:fff047:1:01:01
+
+hsf2:
+hsf2j:
+hsf2j1:
+hsf2d:  ;******Hyper Street Fighter II: The Anniversary Edition (Asia 040202 Phoenix Edition) (bootleg)
+hsf2a:
+0:ffd454:2f:00:58
+0:ffd4cc:4:00:00
+
+gigawing:
+gigawingj:
+gigawinga:
+gigawingb:
+gigawingjd:  ;******Giga Wing (Japan 990223 Phoenix Edition) (bootleg)
+gigawingh:
+gigawingd:
+0:ff70dc:170:00:01
+
+dstlk:
+dstlku:
+dstlkur1:
+dstlka: 
+vampj: 
+vampja: 
+vampjr1:
+dstlku1d:  ;******Darkstalkers: The Night Warriors (USA 940705 Phoenix Edition) (bootleg)
+dstlkh:
+0:fff4aa:5:00:43
+0:fff4af:37:41:00 
+0:ffe976:4:00:00
+
+ddsom:
+ddsoma: 
+ddsomar1: 
+ddsomr1:  
+ddsomjr1:  
+ddsomj:  
+ddsomur1:  
+ddsomu:
+ddsomb:
+ddsomr3:
+ddsomr2:
+ddsomud:  ;******Dungeons & Dragons: Shadow over Mystara (USA 960619 Phoenix Edition) (bootleg)
+ddsomh:  
+0:ff0fd0:8b:12:09
+
+ddtod:
+ddtodu:
+ddtodhr1:  
+ddtodjr1:  
+ddtodj:  
+ddtodur1: 
+ddtodjr2:
+ddtodd:  ;******Dungeons & Dragons: Tower of Doom (Euro 940412 Phoenix Edition) (bootleg)
+ddtoda:
+ddtodar1: 
+ddtodr1:
+ddtodhr2:
+ddtodh:
+0:ff1050:1dd:0a:10
+
+batcirj:
+batcira:
+batcird:  ;******Battle Circuit (Euro 970319 Phoenix Edition) (bootleg)
+batcir:
+0:ff0482:35:00:03
+0:ff04b7:e3:03:00
+
+avspu:
+avspa:
+avspj:
+avsp:
+avspd:  ;******Alien vs. Predator (Euro 940520 Phoenix Edition) (bootleg)
+avsph:  ;******Alien vs. Predator (Hispanic 940520)
+0:ffeac0:31d:01:01
+0:ffedda:1:44:44
+
+19xx:
+19xxar1:
+19xxj:
+19xxa:
+19xxh:
+19xxjr2:
+19xxjr1:  
+19xxb:  
+19xxd:  ;******19XX: The War Against Destiny (USA 951207 Phoenix Edition) (bootleg)
+0:ff4dca:4:00:00
+0:ff0443:9f:14:70
+
+1944:
+1944j:
+1944d:  ;******1944: The Loop Master (USA 000620 Phoenix Edition) (bootleg)
+0:921d90:b8:01:18
+
+fireshrk:
+fireshrkd:  ;******Fire Shark (Korea, set 1, easier)
+fireshrkdh:  ;******Fire Shark (Korea, set 2, harder)
+fireshrka:
+0:c1ae8:194:00:01
+0:c1c29:1:2d:2d
+0:c1dc5:1d:2d:00
+
+3wonders:
+wonder3:
+3wondersu:
+3wondersh:  ;******Three Wonders (hack?)
+3wondersr1:
+3wondersb:
+0:ffd0ce:14:ff:36
+0:ffd0f6:50:00:00
+0:ffd196:28:ff:06
+0:ffd1be:50:00:00
+0:ffd25e:28:ff:ce
+0:ffd286:50:00:00
+0:ff0dae:0c:00:00
+
+tnzs:
+tnzsb:
+tnzsj:
+tnzsjn:
+tnzsjo:
+0:e68d:23:00:55
+tnzso:
+tnzsop:
+0:ec0a:23:00:55
+
+boogwing:
+boogwinga:  
+ragtime: 
+ragtimea:
+boogwingu:
+0:200f4a:27:00:0b
+
+marble:
+marble2:
+marble3:
+marble4:
+marble5:
+0:401e92:32:00:3a
+
+imagoa:
+imago:
+0:c521:4a:00:00
+0:c565:1:01:01
+
+ddragon: 
+ddragonb:
+ddragonu:
+ddragonw:  
+ddragonw1:  
+ddragonua:
+ddragonba:  
+ddragonb2:  ;******Double Dragon (bootleg)
+ddragonub:
+0:0e73:1e:02:2c
+0:0023:3:02:00
+
+starforc:
+starforce:
+megaforc:
+starforcb:
+starforca:
+0:8038:70:00:00
+0:8348:4:00:00
+0:9261:1:23:23
+0:9241:1:23:23
+0:9221:1:23:23
+0:9201:1:1d:1d
+0:91e1:1:18:18
+0:91c1:1:21:21
+0:91a1:1:18:18
+0:9181:1:18:18
+
+ccastles:
+ccastles3:
+ccastlesj:
+ccastles1:
+ccastles2:
+ccastlesf:
+ccastlesg:
+ccastlesp:
+0:474:5dd:00:55
+0:d2:1:03:03
+
+abattle:  
+abattle2:
+astrof:
+acombat3:
+astrof2:
+astrof3:
+afire:  
+acombat:
+acombato:  
+sstarbtl:  ;******Super Star Battle
+0:0084:2:00:00
+0:4268:5:c1:c1
+0:4270:5:c1:c1
+0:4278:5:c1:c1
+0:4280:5:c1:c1
+0:4288:5:c1:c1
+
+tigerhb1:
+tigerhb2:
+tigerh:
+tigerhj:  ;******tiger heli (japan)
+tigerhb3:
+0:c0db:49:00:02
+0:c15a:6:2d:00
+
+wof:
+wofu:
+wofa:
+wofj:
+wofhfh:  ;******Sangokushi II: Huo Fenghuang (Chinese bootleg)
+wofr1:
+wofhfb:
+0:ff6368:0a:00:00
+0:ff77d8:78:ff:10
+0:ff63d4:04:00:00
+
+nightstr:
+nightstrj:  ;******Night Striker (Japan)
+nightstru:  ;******Night Striker (Us)
+0:109b9a:4:00:40
+0:10de48:1f3:00:41
+
+mlander:  ;******Moon Lander (bootleg of Lunar Rescue)
+0:20c0:1:0a:0a
+0:20cf:a:1b:1b
+0:20f4:2:00:05
+
+galastrm:  ;******Galactic Storm (Japan)
+0:202100:190:01:61
+
+captcomm:
+captcommu: 
+captcommj:
+captcommb:  ;******Captain Commando (bootleg)
+captcommr1:
+captcommjr1: 
+0:ff0000:190:08:00
+0:ff018d:1:01:01
+0:ffa8c2:04:00:00
+
+mpangj:
+mpang:
+mpangu:
+mpangr1:
+0:ff817c:1e0:00:01
+
+smgp:
+smgpja:
+smgpj:
+smgpu3:
+smgpu2:
+smgpu1:
+smgpu:
+smgp5:
+smgp6:
+smgp5d:
+smgp6d:
+smgpd:
+smgpjd:
+smgpu1d:
+smgpu2d:
+smgpud:
+0:fff500:7e:21:02
+0:fffe85:1:08:08
+
+wrally:  ;******world rally (set1)
+wrallya:  ;******world rally (set 2)
+wrallyb:  l******world rally (us, 930217)
+wrallyat:
+0:fef558:288:5a:ff
+
+ghox:
+ghoxa:  ;******Ghox (set 2)
+0:805a2:64:00:8e
+0:80006:4:00:00
+
+demonwld:
+demonwld1:  
+demonwld4:  
+demonwld3:  
+demonwld2:
+0:c001c2:c8:00:2d
+0:c001be:4:00:00
+
+paprazzi:  ;******Paparazzi
+0:ff0d99:27:41:3c
+
+heatbrl:  ;******Heated Barrel (World version 3)
+heatbrlu:  ;******Heated Barrel (us)
+heatbrlo:  ;******Heated Barrel (world old version)
+heatbrl2:  ;******Heated Barrel (world version 2)
+heatbrle:
+0:108296:63:4b:01
+0:108036:4:00:00
+
+ffight:
+ffightj:
+ffightjh:
+ffightbl:
+ffightbla:
+0:ff850c:3c:ff:00
+0:ff80a0:04:00:00
+
+ffightj3:
+0:ff850c:3c:ff:00
+0:ff80a0:04:00:03
+
+ffightj2:  ;******Final Fight (Japan 900112)
+ffightj1:
+ffightua:
+ffightu:
+0:ff8520:27:00:50
+0:ff80a0:4:00:01
+ffightub:
+ffightuc:
+0:ff8520:27:00:50
+0:ff80a0:4:00:03
+ffightu1:
+ffighta:
+0:ff850c:3b:ff:50
+0:ff80a0:4:00:00
+
+dynwar:
+dynwarj:
+dynwara:  ;******Dynasty Wars (US set 2)
+dynwarjr:
+0:ffe2d6:3c:e2:00
+0:ff8158:04:00:00
+
+jpopnics:  ;******Jumping Pop (Nics, Korean bootleg of Plump Pop)
+0:c625:27:00:4b
+0:e471:3:00:00
+
+1942:
+1942a:
+1942b:
+1942w:  ;******1942 (Williams Electronics license)
+1942abl:
+1942p:
+0:e800:190:00:00
+0:e9c0:1:1e:1e
+0:e040:8:00:00
+0:e028:1:01:01
+
+dogfgt:  ;******acrobatic dog-fight
+dogfgtj:  ;******acrobatic dog-fight (japan)
+dogfgtu:
+0:607:4f:00:0b
+0:609:1:01:01
+
+rfjet:  ;******raiden fighters jet (all versions fixed)
+rfjeta:  
+rfjetu:  
+rfjets: 
+rfjetj:  
+rfjet2kc:
+rfjetsa:
+rfjett:
+0:28dd4:98:2e:01
+
+pzloop2:  ;******puzz loop 2 (euro 010302)
+pzloop2j:
+;** stage scores not right ** ** you must wait untill the hiscore table has displayed **
+;** at least once before you start a game for this save to work  ****
+0:ff2cbc:3ae:4d:20
+0:ff2cc8:1:20:20
+
+bjtwin:
+bjtwina:  ;******Bombjack Twin (set 2)
+bjtwinp:
+atombjt:
+0:f9100:a0:00:4c
+
+tdragonb:
+tdragon:  ;******Thunder Dragon (9th Jan. 1992)
+tdragon1:  ;******Thunder Dragon (4th Jun. 1991)
+0:b9100:c0:00:20
+
+pitfall2:
+pitfall2u:
+pitfall2a:  ;******Pitfall II (315-5093, Flicky Conversion)
+0:D300:38:00:41
+0:C000:04:00:00
+
+riskchal:  ;******risky challenge
+gussun:
+0:a3c6b:1ba:00:18
+
+;*******(dr.micro)
+drmicro:
+0:c000:1:01:01
+0:c800:10e:00:00
+0:c017:6:00:00
+
+orbs:  ;******Orbs (10/7/94 prototype?)
+0:f01d35:151:06:08
+
+;********supbtime.c
+supbtime:
+supbtimej:
+supbtimea:
+0:10002c:50:00:4f
+
+;********skykid.c
+skykid:
+skykido:
+skykidd:
+skykids:
+0:5000:45:00:0a
+0:5001:1:03:03
+
+hangon:
+hangon1:  ;******Hang-On
+hangon2:
+0:20c488:4:01:00
+0:20d800:4a0:01:20 ; note best lap time are not saved
+
+guts:  ;******Guts n' Glory (prototype)
+0:fffdd4:c8:00:a4
+
+extrmatn: ;[Special thanks to Cananas for enhancing this entry]
+extrmatnj: ;******Extermination (Japan)
+extrmatnu:
+extrmatnur:
+0:e8a5:28:00:55
+0:e888:01:00:00
+0:e887:01:49:49
+0:e886:01:00:00
+
+toride2g:  ;******toride ii adouchi gaiden
+toride2gk: 
+0:40c5f4:4:00:00
+0:40c5f6:1:50:50
+0:40c60a:4c:00:40
+
+toride2gg:  ;******toride ii adouchi gaiden (german)
+0:40ece2:4c:00:40
+0:40ecc6:4:00:00
+0:40ecc8:1:50:50
+
+toride2j:  ;******Toride II Adauchi Gaiden (Japan)
+0:40ecc0:5c:00:40
+0:40eca4:4:00:00
+0:40eca6:1:50:50
+
+pang:
+pangb:
+pompingw:
+bbros:
+pangbold:
+pangba:  ;******Pang (bootleg, set 3)
+pangb2:
+0:f9e3:9A:01:00
+0:e00d:3:01:00
+
+aliensyn:
+aliensynjo: ;******Alien Syndrome (set 1, System 16A, FD1089a 317-0033)
+aliensyn2: ;******Alien Syndrome (set 2, System 16A, FD1089a 317-0033)
+aliensyn3: ;******Alien Syndrome (set 3, System 16b, FD1089a 317-0033)
+aliensyn5:
+aliensynj:
+aliensyn7:
+0:fff300:46:00:01
+0:ffc060:4:00:00
+
+airwolf:
+skywolf:
+skywolf2:
+airwolfa:  ;******Airwolf (US)
+skywolf3:
+0:e71a:5f:00:ff
+
+tehkanwc:
+tehkanwcb:  ;******Tehkan World Cup (set 2, bootleg?)
+tehkenwcc:
+0:c600:60:03:17
+
+;tantr (& clones) hiscores update after hiscore table is displayed in attract mode
+tantr:
+tantrbl:
+tantrbl2:
+tantrkor:  
+tantrbl3:  ;******Puzzle & Action: Tant-R (Japan) (bootleg set 3)
+0:fffc45:28:48:00
+
+;** this only saves the hiscore table, the top score will stay at default **
+sqix:  
+sqixr1:  
+sqixu:  
+sqixb1:  
+sqixb2:
+0:f4c0:28:00:03
+
+rongrong:  ;******puzzle game rong rong (europe)
+0:614f:ea:f4:01
+0:619c:1:01:01
+
+rongrongg:  ;******puzzle game rong rong (germany)
+rongrongj:  ;******puzzle game rong rong (japan)
+0:614e:ea:f4:01
+0:619b:1:01:01
+
+loht:  
+lohtj:
+lohtb2:
+0:a3af4:32:36:20
+0:a3adc:02:36:11
+
+djboy:  ;******dj boy (set 1)
+djboya:  ;******dj boy (set 2)
+djboyj:  ;******dj boy (japan)
+0:b16a:2d:01:12
+
+hunchbak:
+hunchbaka:  ;******Hunchback (set 2)
+0:1c07:68:00:00
+0:1c34:1:20:20
+
+hunchbks:
+hunchbks2:
+0:3c0a:4f:1b:00
+0:3c25:1:20:20
+
+hunchbkd:
+0:1c23:4f:1b:00
+0:1c73:1:01:01
+
+hunchbkg:
+0:1c0a:4f:1b:00
+0:1c0f:1:00:00
+0:1c0d:1:20:20
+
+shinobi:
+shinobl:
+shinobi1:
+shinobi2:
+shinobi3:
+shinobi4:
+shinobi5:  
+shinobld:
+shinobls:  ;******Shinobi (Star bootleg, System 16A)
+shinoblda:
+shinobi1d:
+shinobi2d:
+0:fffc00:142:00:54
+0:fff010:4:00:00
+
+loverboy:  ;******loverboy
+trikitri:
+0:8026:3c:04:13
+
+fghthist:  ;******fighters history (world ver 43-07)
+fghthista:  ;******fighters history (us ver42-05, alternative hardware)
+fghthistua:  ;******fighters history (us ver42-03)
+fghthistja:  ;******fighters history (japan ver 42-03)
+fghthistj:
+fghthistub:
+fghthistjb:
+fghthistuc:
+fghthistu:
+fghthistb:
+0:1019d8:28:50:00
+
+dominob:  ;******Domino Block
+0:ef79:23:03:4b
+0:c4df:3:03:00
+
+puzznic:
+puzznicj:
+puzznici:  ;****** Puzznic (Italy)
+puzznicb:
+puzznicba:
+0:8f23:32:00:49
+0:8d37:3:00:00
+
+venus:  ;******venus
+0:9489:26:00:d3
+0:940b:3:00:01
+
+dockman:
+portman:
+porter:  ;******Port Man (bootleg on Moon Cresta hardware)
+0:80fd:3:00:00
+0:92c1:1:00:00
+0:92e1:1:24:24
+0:9301:1:24:24
+0:9321:1:24:24
+0:9341:1:24:24
+0:9181:1:00:00
+0:91a1:1:24:24
+0:91c1:1:24:24
+0:91e1:1:24:24
+0:9201:1:24:24
+
+hrdtimes:  ;******Hard Times (set 1)
+hrdtimesa:  ;******Hard Times (set 2)
+0:85b44:a0:00:11
+0:85c14:4:00:00
+
+mooncrst:
+smooncrs:
+mooncrsb:
+mooncrs2:
+fantazia:
+eagle:
+eagle2:
+eagle3:
+mooncrs3:  
+spcdrag:   
+spcdraga:  
+mooncmw:  ;******Moon War (Moon Cresta bootleg)
+mooncrstu:
+stera: 
+mooncrstuk:
+sstarcrs:
+mooncrstuku:
+mooncrs4:
+starfgmc:
+mooncptc:
+mooncreg:
+mooncrsl:
+mooncrstso:
+0:8042:54:00:24
+
+mooncrgx:
+0:4042:54:00:24
+
+mooncrstg:
+0:8045:54:00:24
+
+;******(moon cresta (nichibutsu, old rev))
+mooncrsto:
+0:8042:54:00:24
+0:804f:1:50:50
+
+galaxian:
+galaxianm:
+superg:
+galaxb:
+galapx:
+galap1:
+galap4:
+galturbo:
+swarm:
+uniwars:
+gteikoku:
+spacbatt:
+spacbat2:
+redufob:
+galaxiana:
+galaxianmo:  
+galaxbsf:  
+galaxiant:
+skyraidr:
+spacempr:
+redufo:
+galemp:
+astrians:
+asideral:
+galaxrf:
+galaxianbl:
+pajaroes:
+galaxbsf2:
+galaxiani:
+galaxrfgg:
+zerotimed:
+supergs:
+0:40a8:3:00:00
+
+gteikokb:
+gteikob2:
+0:40a8:3:00:00
+0:51a1:1:00:00
+0:51c1:1:00:00
+0:51e1:1:10:10
+0:5201:1:10:10
+0:5221:1:10:10
+0:5241:1:10:10
+
+
+
+kamakazi3:
+moonaln:
+kamikazp:
+0:44a8:3:00:00
+0:55a1:1:90:90
+0:55c1:1:90:90
+0:55e1:1:10:10
+0:5601:1:10:10
+0:5621:1:10:10
+0:5641:1:10:10
+
+
+exodus:
+0:40a8:3:00:00
+0:40ac:1:70:70
+0:55c1:1:90:90
+0:55a1:1:90:90
+0:5621:1:10:10
+0:5641:1:10:10
+0:5601:1:10:10
+0:55e1:1:10:10
+
+
+
+strahla:  ;******koutetsu yousai strahl (japan set 2)
+0:f30d1:d9:55:2e
+0:f3239:27:00:88
+0:f0d5b:3:00:50 
+
+;*******jump coaster
+jumpcoas:
+jumpcoast:  ;******Jump Coaster (Taito)
+0:c400:3f:00:11
+0:c04b:3:00:00
+0:c41c:1:05:05
+
+digdug:
+digdug1:
+digdugat:
+dzigzag:
+digdugat1:  ;******dig dug (atari, rev1)
+0:89A0:25:01:01
+
+flicky:
+flickyo:
+flickys2:  ;Flicky (128k Version, System 2, not encrypted)
+flickys1:  ;Flicky (64k Version, System 1, 315-5051, set 2)
+0:e700:31:00:41
+0:c0d5:3:00:00
+
+mstworld:  ;******monsters world
+0:fc01:9e:00:07
+0:e154:3:00:00
+
+airattck: 
+airattcka:  ;******Air Attack (set 2)
+0:b9100:80:0:6b
+
+sdfight:  ;******SD Fighter (Korea)
+0:121efa:4f:00:4d
+
+funybubl:
+funybublc:  ;******Funny Bubble (Comad version)
+0:e005:99:4c:00
+0:e09a:1:05:05
+
+hexpoola:  ;******Hex Pool (Senko)
+hexpool:  ;******hex pool (shinkai)
+0:1db8:45:1d:13
+
+captaven:
+captavenj:  ;******captain america and the avengers (jap rev 0.2)
+captavena:  ;******captain america and the avengers (asia rev 1.0)
+captavene:  ;******captain america and the avengers (uk rev 1.4)
+captavenua:  ;******captain america and the avengers (us rev 1.4)
+captavenuu:  ;******captain america and the avengers (us rev 1.6)
+captavenu:  ;******captain america and the avengers (us rev 1.9)
+0:127040:A0:20:0
+
+vr:  ;******virtua racing
+vformula:  ;******virtua formula
+0:40e000:6bf:01:20
+
+;********ribbit!(By Firebrand)
+ribbit:
+0:fffada:126:ff:ff
+0:ffc45f:1:03:03
+
+tangtang:  ;******tang tang (ver.0526,26/05/2000)
+0:70a840:40:00:40
+
+meikyuha:  ;******Meikyuu Hunter G (Japan, set 2)
+meikyuh:  ;******Meikyuu Hunter G (Japan, set 1)
+0:190:50:01:20
+
+chinhero:
+chinhero2:  ;******chinese hero (older)
+chinherot:
+chinhero3:
+0:e132:46:00:17
+0:e128:4:00:00
+0:e12a:1:03:03
+
+asurabus:  ;******Asura Buster - Eternal Warriors (Japan)
+asurabusa:
+0:40326d:132:05:14
+
+dynabomb:  ;******Dynamite Bomber (Korea) (Rev 1.5)
+0:c7908:60:00:01
+0:c7e43:1:03:03
+
+airbustr:
+airbustrj:  ;******Air Buster: Trouble Specialty Raid Unit (japan)
+airbustrb:  ;******Air Buster: Trouble Specialty Raid Unit (bootleg)
+0:e160:40:01:01
+0:e19e:01:4f:4f
+
+troangel:
+newtangl:  ;******New Tropical Angel
+0:e780:1e:02:4e
+0:e0d3:3:02:00
+
+tokib:
+tokiu:
+tokia:  ;******Toki (World Set 2)
+juju:  ;******JuJu Densetsu (Japan)
+jujub:  ;******JuJu Densetsu (Japan, bootleg)
+tokiua:
+jujuba:
+tokip:
+0:66b66:b4:00:03
+0:60008:4:00:00
+
+;*********pstadium.c (toki (world set 1))
+toki:
+0:66b5e:b4:00:03
+0:60008:4:00:00
+0:6000a:1:20:20
+
+circus:
+circusse:  ;******Circus (Sub-Electro bootleg)
+springbd:
+0:0036:2:00:00
+
+gground:
+ggroundj:  ;******Gain Ground (Japan, FD1094 317-0058-03b)
+0:f07800:318:00:00
+0:f07b13:1:10:10
+
+;** tong boy sub-game does not save , driver issues ???? **
+nmg5:
+nmg5e:  ;******Multi 5 / New Multi Game 5 (earlier)
+nmg5a:
+0:129101:ff:10:40
+
+photoy2k104:
+photoy2k102:
+0:80a306:1:12:12
+0:813452:78:49:40
+0:833452:78:49:40
+0:853452:78:49:40
+0:873452:78:49:40
+0:893452:78:49:40
+0:8b3452:78:49:40
+0:8d3452:78:49:40
+0:8f3452:78:49:40
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.107 additions below - by leezer   *
+;***********************************************************************
+
+hyprduel2:
+hyprduel:  ;******hyper duel (japan set 1)
+0:fff2a2:3c:00:01
+0:fff2e2:1:ff:ff
+
+brdrline:  
+starrkr: 
+brdrlinb:  
+brdrlins:  ;******Borderline (Sidam bootleg)
+0:938d:2:00:00
+
+popnpop:
+popnpopu:  ;******pop n pop (ver 2.07a 1998/02/09)
+popnpopj:  ;******pop n pop (ver 2.07j 1998/02/09)
+0:40a668:d2:00:ba
+
+;** this saves scores 4 - 98 , the nvram file saves scores 1 - 3 **
+tempest: ;******tempest (rev 3) *
+tempest1: ;******tempest (rev 1) *
+tempest2: ;******tempest (rev 2) *
+temptube: ;******tempest tubes *
+tempest3: ;******tempest (rev ?) *
+0:1d:1:03:03
+0:605:11a:14:00
+
+;******free kick (bootleg)
+freekickb:
+freekickb2:
+freekick:
+freekickb1:
+freekicka:
+0:d100:4d:00:21
+
+;******brain
+brain:
+0:d300:3c:00:49
+0:c017:3:00:05
+
+turtship:
+turtshipk:  
+turtshipj:  ;******turtle ship (japan)
+turtshipkn:
+turtshipko:
+0:c504:96:00:0a
+0:c202:2:00:1e
+
+;******Daikaiju no Gyakushu
+daikaiju:
+0:bf00:a0:00:33
+0:a007:3:00:05
+0:a027:1:23:23
+0:d798:b:30:30
+
+;** only top score saved properly, although all other scores do save **
+;** they go in the wrong order ???? **
+madalien:
+madaliena:  ;******Mad Alien (Highway Chase)
+madalienb:
+0:000b:2:00:00
+0:6ef0:d6:00:00
+0:300:c:00:00
+0:604d:5:01:01
+0:6050:1:01:01
+
+spaceod:  ;******space odessy (fixed) *
+spaceod2:
+0:c907:2:0:0
+0:c921:1:05:05
+
+monsterb:  ;******monster bash (fixed)  *
+monsterb2:  ;******monster bash (2 board version) (fixed)  *
+0:c913:3:00:00
+0:c8f6:1:0d:0d
+
+005: ;******005 ;[Special thanks to Cananas for enhancing this entry]
+0:c910:0b:99:00
+
+ddenlovr:  ;******don den lover vol.1 (hong Kong)
+0:ff853a:74:82:3c 
+
+tryout:  ;******pro baseball skill tryout (japan)
+0:319:29:90:00
+0:33d:1:01:01
+0:13:3:07:90
+
+nslasher:  
+nslasherj:  
+nslasheru:
+nslashers:  ;******Night Slashers (Over Sea Rev 1.2)
+0:100044:50:13:00
+0:100092:1:05:05
+
+kbash2:  ;******Knuckle Bash 2 (bootleg)
+0:100080:3c:00:30
+
+upscope:  ;******Up Scope
+0:3e4f6:1e:43:45
+0:3e5fc:28:00:98
+
+thepitj:
+thepitu1:
+thepit:  ;******The Pit (Bootleg)
+0:8283:17:10:0
+0:8039:f:10:0
+
+thepitm:
+0:8283:17:14:0
+0:8039:f:14:0
+
+thepitu2:
+0:8283:17:10:00
+0:8037:f:10:00
+
+amidar: ;[Special thanks to Cananas for enhancing this entry]
+amidarb:
+amidaro:
+amidaru: 
+amigo:
+amidar1:
+0:8200:1e:00:01
+0:80a8:03:00:01
+
+amidars:
+0:4200:1e:00:01
+0:40a8:03:00:01
+
+realbrk:
+realbrkj:  
+realbrkk:  ;******Billiard Academy Real Break (Korea)
+realbrko:
+0:ff84da:44:52:f8
+
+mangchi:  ;******Mang-Chi
+0:1c1b02:4c:27:20
+
+cawing:
+cawingj: 
+cawingu:
+cawingr1:  ;******Carrier Air Wing (World 901009)
+cawingbl:
+cawingb2:
+0:ffd9b4:28:00:00
+0:ffda04:14:ff:d4
+0:ffda2c:04:00:00
+
+;*** puckman/pacman (and clones) for pacmame & regular mame builds **
+hangly3:
+zolamaze:
+mspatkx:
+mspacx:
+msmini:
+mspacat2:
+msatk2ad:
+msatkad:
+mspacatk:
+chtmsatk:
+fastplus:
+mspacatb:
+mshearts:
+mssilad:
+fstmsatk:
+mspac6m:
+msminia:
+chtmspa:
+fastmspa:
+msrumble:
+msindy:
+fasthear:
+heartbrn:
+mshangly:
+msf1pac:
+mselton:
+faststrm:
+msdstorm:
+msbaby1:
+msbaby:
+mrpacman:
+pacmanf:
+puckmanf:
+pacmini2:
+pacmini:
+mazeman:
+hangly2x:
+hanglyx:
+hanglyad:
+fasthang:
+chthang:
+eltonpac:
+dizzy:
+pacstrm:
+crazypac:
+caterpil:
+baby2:
+baby3:
+pacman:
+pacmanm:
+pacmanjp:
+npacmod:
+pacmod:
+hangly:
+hangly2:
+puckman:
+puckmanb:
+piranha:
+piranhah:
+pacplus:
+mspacman:
+mspacmnf:
+mschamps:
+newpuc2:
+newpuc2b: 
+joyman: 
+mspacpls:
+pacgal:
+newpuckx:
+alibaba:
+mspacmat: 
+puckmod:
+puckmana:
+ctrpllrp:  
+puckmanh: 
+piranhao:
+abscam:  ;******Abscam 
+mspacmbe:  ;******Ms. Pac-Man (bootleg, (encrypted))
+popeyeman:
+bucaner:
+alibabab:
+crockman:
+mspacii:
+mspacii2:
+msheartb:
+mspacmanbg:
+mspacmancr:
+mspacmanbcc:
+mspacmanbgd:
+pacmanjpm:
+pacgal2:
+00:4E88:04:00:00
+00:43ED:06:40:40
+00:43D1:01:48:48
+
+mspacmanbhe:
+pacmanpe:
+pacmanso:
+00:4E88:04:00:00
+00:43ED:06:40:40
+00:43c6:01:55:55
+
+clubpacm:
+0:4E88:04:00:00
+0:43ED:06:40:40
+0:43D1:01:59:59
+0:43cb:0a:4f:4d
+
+mspacmanblt:
+00:4E88:04:00:00
+00:43ED:06:40:40
+00:43D1:01:54:54
+
+pacuman:
+00:4E88:04:00:00
+00:43ED:06:40:40
+00:43D1:01:45:45
+
+pac90:
+0:8e88:3:00:00
+0:8180:1:40:40
+0:81a0:1:40:40
+0:81c0:1:40:40
+0:81e0:1:40:40
+0:8200:1:40:40
+0:8220:1:40:40
+0:8dce:1:03:03
+
+;** wardner,wardner (japan),pyros all fixed  * 
+wardner:
+wardnerj:
+pyros:
+0:7116:5d:00:01
+0:711a:1:20:20
+
+pangpang:  ;******Pang Pang
+0:123c10:a0:44:50
+
+fantsia2:
+fantsia2a:  ;******Fantasia II (set 2, less explicit)
+fantsia2n:
+0:f825b6:64:30:00
+
+bonzeadv:
+bonzeadvo:  ;******Bonze Adventure (World, Older)
+bonzeadvu:  ;******Bonze Adventure (us)
+jigkmgri:
+0:10d554:32:00:2a
+0:10d52a:4:00:00
+0:10d52b:1:05:05
+
+bonzeadvp:
+0:10d552:32:00:2a
+0:10d528:4:00:00
+0:10d529:1:05:05
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.105 additions below - by leezer   *
+;***********************************************************************
+
+batlbubl:  ;******Battle Bubble (v2.00)
+0:f04b24:9a:54:03
+
+eyes:
+eyes2:
+eyeszac:  ;******Eyes (Zaccaria)
+eyeszacb:
+eyesb:
+0:4cf7:3c:4c:00
+0:43ed:6:00:40
+
+kazan:  ;******Ninja Kazan (World)
+0:f4001:97:20:ac
+0:f0004:4:00:00
+0:f0010:08:30:30
+
+toppyrap:  ;******toppy & rappy
+0:10372f:42:00:45
+
+rpatrol:  ;******River Patrol (Orca)
+0:919b:4:18:0a
+0:91ba:6:00:00
+0:921b:4:18:0a
+0:923a:6:00:00
+0:929b:4:18:0a
+0:92ba:6:00:00
+
+;********cclimber.c (river patrol (bootleg))
+rpatrolb:
+0:919b:4:11:18
+0:91ba:6:00:00
+0:921b:4:11:18
+0:923a:6:00:00
+0:929b:4:11:18
+0:92ba:6:00:00
+
+silvland:
+0:919b:4:0f:26
+0:91ba:6:00:00
+0:921b:4:0c:26
+0:923a:6:00:00
+0:929b:4:15:26
+0:92ba:6:00:00
+
+starfght:  ;******Star Fighter
+0:40a8:3:00:00
+0:5241:1:10:10
+0:5221:1:10:10
+0:5201:1:10:10
+0:51e1:1:10:10
+0:51c1:1:90:90
+0:51a1:1:90:90
+
+slapfighb2:
+slapfighb1:
+slapfighb3:  ;******Slap Fight (bootleg)
+slapfigh:
+alcon:
+0:c05d:49:50:04
+0:c118:7:2d:00
+
+news:
+newsa:  ;******News (set 2)
+0:e4bb:8:30:30
+
+moomesa:
+moomesaa:  ;******Wild West C.O.W.-Boys of Moo Mesa (ver AA)
+moomesaua:  ;******Wild West C.O.W.-Boys of Moo Mesa (ver ua)
+moomesabl:
+0:1801e0:97:00:1a
+
+circusc:
+circusc2:
+circuscc:
+circusce:
+circusc3:  ;******circus charlie (no level select)*
+circusc4:
+0:2160:32:01:FE
+0:20A6:3:01:30
+0:35A7:1:00:00
+0:35C7:1:03:03
+0:35E7:1:08:08
+0:3607:1:09:09
+0:3627:1:01:01
+0:3647:1:10:10
+
+multchmp:
+multchmpk:  ;******multi champ (korea)
+0:10a841:3f:10:40
+
+htchctch:  ;******hatch catch
+0:120faa:27:00:45
+
+pollux:
+polluxa:  ;******pollux (set 2)
+polluxa2:  ;******Pollux (set 3)
+polluxn:
+0:c082:9f:88:2e
+
+outzone:
+outzonea:
+outzoneb: 
+outzonec:  ;******outzone (set 4)
+outzoned:
+outzoneh:
+0:2401de:18:00:00
+0:240503:4f:3f:3f
+0:240372:a:00:00
+
+dbreed:  ;******Dragon Breed (M81 pcb version)
+0:88990:82:58:2e
+0:8896a:3:58:00
+0:88959:1:2b:2b
+
+dbreedm72:  ;******dragon breed (m72 pcb version)
+0:9096a:03:58:00
+0:90990:82:58:2e
+0:90950:01:06:06
+
+tokio:  ;******Tokio / Scramble Formation
+tokiou:  ;******Tokio / Scramble Formation (us)
+tokioo:
+0:c858:f:00:2a
+0:c85c:1:01:01
+0:f4c0:3:61:00
+
+;(tokio/scramble formation(bootleg)) clone (by GeoMan)
+tokiob:
+0:f4bf:4:00:00
+0:c858:f:00:2a
+
+bombkick:  ;******Bomb Kick
+bombkicka:
+0:ff8044:46:00:20
+
+agress:   ;*
+agressb:  ;******Agress (English bootleg)
+0:1d5c0a:4:00:00
+0:1d5c81:1:1d:1d
+
+theglob3:  ;******the glob (set 3)
+0:7a5f:3c:00:00
+0:7ab1:1:01:01
+0:7ab7:1:80:80
+
+theglobp:  ;******the glob (pac-man hardware)
+0:4c48:3c:4d:00
+0:4c93:1:01:01
+0:4cb9:1:15:15
+
+theglob:  ;******the glob *
+theglob2:  ;******the glob (earlier)*
+0:7bf9:3c:00:00
+0:7c4b:1:01:01
+0:7c51:1:80:80
+
+beastf:  ;******beastie feastie
+0:4c46:3c:4d:00
+0:4c8a:1:01:01
+0:4cb0:1:15:15
+
+suprglob:  ;******super glob *
+0:7c20:3c:00:00
+0:7ca4:1:d8:d8
+0:7c72:1:01:01
+
+sprglbpg:  ;******Super Glob (Pac-Man hardware)german
+sprglobp:  ;******Super Glob (Pac-Man hardware)
+0:4c48:3c:4d:00
+0:4cb9:1:15:15
+0:4c93:1:01:01
+
+burnforc:
+burnforco:  ;******Burning Force (Japan old version) 
+0:100171:bb:00:48
+0:100175:1:08:08 
+
+darkmist:  ;******The Lost Castle In Darkmist
+0:e01d:8c:00:20
+
+thunderx:
+thunderxj:
+thunderxa:  ;******thunder cross (set 2)
+thunderxb:  ;******thunder cross (set 3)
+0:4050:4:00:00
+0:4100:50:11:00
+0:414e:1:10:10
+
+sharrier:
+sharrirb:  ;******Space Harrier (8751 317-0063?)
+0:40488:4:01:00
+0:43400:3dc:01:20
+0:437dc:2:00:00
+
+mvp:  ;******mvp (set 2, japan,fd1094 317-0142)
+mvpj:  ;******mvp (set 1, us,fd1094 317-0143)
+mvpd:
+mvpjd:
+0:ff3800:8b:01:01
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.104 additions below - by leezer   *
+;***********************************************************************
+
+missw96:
+missmw96:  ;******Miss Mister World '96 Nude
+missw96a:
+missw96b:
+missw96c:
+0:c025b6:1d:30:53
+
+;** this saves the daily hiscores(daily heros), the legendary heros are saved in nv ram **
+joust2:      ;******joust 2 - survival of the fittest (set 1)
+joust2r1:
+0:cfaa:54:f1:f9
+
+;** this saves the daily hiscores(daily buzzards), the joust champions are saved in nv ram **
+joust:  ;******joust (white/green label)
+joustr:  ;******joust (solid red label)
+joustwr:
+0:cfa4:54:f1:f5
+
+laserbat:  ;******laser battle
+0:1cf1:1e:cb:00
+0:1d0d:1:60:60
+
+lazarian:  ;******lazarian
+0:1f07:1e:00:d4
+
+spaceint:
+spaceintj:  ;******Space Intruder (Japan)
+0:2000:3:0:0
+
+catnmous:  ;******Cat and Mouse (set 1)
+0:1f0a:1e:cb:00
+0:1f24:1:d4:d4
+
+thoop:  ;******thunder hoop (ver.1)
+0:ffe5d4:a0:00:0a
+0:ffd2ea:4:00:40
+
+skullfng:  ;******skull fang (japan)
+skullfngj:
+0:100a80:f0:00:12
+0:100040:1:08:08
+
+backfire:  ;******backfire!
+backfirea:  ;******backfire! (set 2)
+0:170300:1b0:13:11
+
+rocknmsb:  ;******Rock'n MegaSession (Japan, bootleg)
+0:1043bd:14d:3d:00
+0:104507:1:18:18
+
+twinactn:  ;******Twin Action
+0:f9091:3:00:10
+
+rockn:  ;******Rock'n Tread (Japan)
+0:104351:3b:3d:06
+0:1043c9:3b:3d:06
+
+rocknb:  ;******Rock'n Tread 1 (Japan, bootleg)
+0:104351:3b:3d:06
+0:1043c9:3b:3d:06
+
+rockn4b:  ;******Rock'n 4 (Japan, prototype, bootleg)
+0:1043bf:13b:3d:06
+
+rockn3b:  ;******Rock'n 3 (Japan, bootleg)
+0:1043b1:13b:3d:06
+
+rockn2b:  ;******Rock'n Tread 2 (Japan, bootleg)
+0:104383:13b:3d:06
+
+mgcrystlo:  ;******Magical Crystals (World, 91/12/10)
+0:30047a:7a:00:00
+0:3004f1:1:46:46
+0:30047b:1:09:09
+mgcrystl:
+0:300478:4:00:09
+0:30047c:7c:00:00
+mgcrystlj:
+0:300488:4:00:00
+0:30048c:7c:41:00
+
+alien3:
+alien3u:  ;*******alien 3: the gun (us)  
+0:20f2bc:78:80:00
+
+shuttlei:  ;******shuttle invader
+0:4008:3:00:00
+
+avengrgs:  ;******avengers in galactic storm (us)
+avengrgsj:  ;******avengers in galactic storm (japan)
+0:108909:4e:01:52
+
+hvysmsh: ;[Special thanks to Cananas for enhancing this entry]
+hvysmshj: 
+hvysmsha:
+0:100400:50:01:00
+0:10000c:04:00:00
+
+powernjb:  ;******gouketsuji ichizoku(japan, bootleg)
+0:18e800:28:00:05
+
+plegends:  ;******Power Instinct Legends (USA)
+plegendsj:  ;******Gouketsuji Ichizoku Saikyou Densetsu (Japan)
+0:40e800:3b:00:0c
+
+tstrike:  ;******Thunder Strike (Newer)
+tstrikea:  ;******Thunder Strike (older)
+0:cf5:55:42:30
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.103 additions below - by leezer   *
+;***********************************************************************
+
+supmodel:  ;******super model
+0:c825b6:63:30:20
+
+powerins:
+powerinsa:  ;******power instinct (usa, bootleg set 1)
+powerinsb:  ;******power instinct (usa, bootleg set 2)
+powerinsj:
+0:18e800:28:00:05
+
+madball:  ;******Mad Ball V2.0
+madballn:
+0:eb3b:1e:41:00
+0:eb57:1:01:01
+
+tp84:
+tp84a:  ;******time pilot '84 (set 2)
+0:57a0:1e:00:54
+0:5736:03:00:00
+
+tp84b:  ;******time pilot '84 (set 3)
+0:17a0:1e:00:54
+0:1736:3:00:00
+
+;******Multi Champ Deluxe
+mchampdx:
+mchampdxa:  ;******Multi Champ Deluxe (ver. 1126, 26/11/1999)
+0:20a900:200:00:40
+
+arabfgt:
+arabfgtj: 
+arabfgtu:  ;******Arabian Fight (us)
+0:208300:49:53:00
+0:208345:1:17:17
+
+powerbal:  
+powerbals:  ;******power balls (super slam conversion)
+0:f8276:7c:56:00
+0:f82f0:1:20:20
+
+kidniki:
+kidnikiu:  ;******Kid Niki - Radical Ninja (us)
+0:e062:69:00:2e
+0:e02b:3:00:00
+
+;******Little Hero
+lithero:
+0:e062:6e:00:44
+0:e02b:3:00:00
+
+yanchamr:
+0:e062:6e:00:20
+0:e02b:3:00:00
+
+kageki:
+kagekij:
+kagekih:  ;******Kageki (World?, hack)
+0:e057:a:05:50
+0:e061:f:87:8c
+
+splatter:
+splatterj:  ;*****splatter house (japan)
+splatter2:
+1:1430:3f:00:2e
+
+vbowlj:  ;******Virtua Bowling (Japan, V100JCM) 
+vbowl:
+0:101c32:44:00:2e
+
+stkclmns:
+stkclmnsj:  ;******Stack Columns (japan)
+0:fffc24:38:4b:88
+
+redclash: 
+redclasha:
+0:6023:4:00:00
+0:6320:6:23:1d
+redclashk:
+0:6023:4:00:00
+0:6320:6:1a:1e
+
+kikikai:
+knightb:  ;******Knight Boy
+0:e2fc:23:00:55
+
+zigzag:  ;******zig zag (galaxian hardware, set 1)
+zigzagb:
+zigzagb2:
+zigzag2:  ;******zig zag (galaxian hardware, set 2)
+0:4280:3:00:00
+0:5242:1:10:10
+0:5222:1:10:10
+0:5202:1:10:10 
+0:51e2:1:10:10
+0:51c2:1:00:00
+0:51a2:1:00:00
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.102 additions below - by leezer   *
+;***********************************************************************
+
+varth:
+varthj:
+varthu:
+varthr1:  ;******varth - operation thunderstorm (world 920612)
+varthjr:
+0:fff9ea:50:00:01
+0:fffa42:04:00:00
+
+vandyke:
+vandykeb:
+vandykejal:  ;******Vandyke (Jaleco, Set 1)
+vandykejal2:  ;******Vandyke (Jaleco, Set 2)
+0:f0101:ff:00:2e
+0:f00d1:3:00:00
+
+trckydoca:  ;******Tricky Doc (Set 2)
+0:e03c:78:10:46
+
+rohga:
+rohgah:  
+rohgau:  
+rohga1:  ;******rohga armour force (asia/europe v3.0 set 1)
+rohga2:  ;******rohga armour force (asia/europe v3.0 set 2)
+wolffang:
+0:3f0200:50:00:09 
+
+;** these are untested as the dont work in this version of mame (mame v0.96u1) **
+mtlchampj:  
+mtlchamp:  
+mtlchampa:  
+mtlchampu:  
+mtlchamp1:  ;******martial champion (ver eaa)
+mtlchampu1:
+0:100300:61:00:44
+
+metamrph:
+metamrphj:  ;******Metamorphic Force (ver jaa)
+metamrphu:  ;******Metamorphic Force (ver uaa)
+0:203240:35:00:5a
+
+raimais:
+raimaisj:  
+raimaisjo:
+0:a237:30:50:4b
+
+wondstck:  ;******Wonder Stick 
+wondstcka:
+0:12c354:3b:57:30
+
+splash:
+splash10:  ;******Splash! (Ver. 1.0 World)
+0:ffca10:50:00:00
+0:ffca5e:1:27:27
+
+sichuan2:
+sichuan2a:
+shisen:
+matchit:  ;******match it
+0:fcae:52:50:01
+
+batsugun: ;[Special thanks to Cananas for making this entry work]
+batsuguna:
+batsugunsp:
+batsugunb:
+0:10109e:04:00:00
+0:101166:70:00:00
+0:1011b5:01:15:15
+
+puzloopj:  ;******Puzz Loop (Japan)
+0:609d080:41:00:31
+0:609d1a8:41:00:30
+
+puzloopu:
+puzloopk:  ;******Puzz Loop (Korea)
+0:609c5d8:41:00:31
+0:609c700:41:00:30
+
+metlsavr:  ;******Metal Saver
+0:341600:63:03:44
+
+ninjak:
+ninjaku:  ;******The Ninja Kids (US)
+ninjakj:  ;******The Ninja Kids (Japan)
+0:102b80:48:00:20
+
+bnzabros:
+bnzabrosj:  ;******Bonanza Bros (Japan, Floppy DS3-5000-07b)
+0:f00700:98:00:4d
+0:f00701:1:31:31
+
+zipzap:  ;******Zip & Zap
+0:c80502:4e:4e:41
+
+watrball:  ;******Water Balls
+0:fed53c:4a:4e:00
+
+egghunt:  ;******Egg Hunt
+0:f000:70:45:00
+0:f06b:1:03:03
+
+fcrash:  ;******Final Crash (World, bootleg)
+0:ff850c:3c:ff:00
+0:ff80a0:4:00:00
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.100 additions below - by leezer   *
+;***********************************************************************
+
+;** both star wars revisions, fixed - you must delete the starwars/starwars1 nvram files/s
+;** before using this save, also delete both starwars/starwars1 .hi files also, and theres more
+;** you must have nvram saving enabled in the games service menu (f2) i think nvram saving is on by
+;** default anyway.
+;**UPDATE** this was working untill mame 0.104 disabled for now !!  ****
+starwars:  ;******star wars (rev 1)
+starwars1:  ;******star wars (rev 2)
+0:4a9a:1c:00:55
+0:4abf:15:07:0d
+
+;** top 3 scores saved by nvram, this saves other scoretable data **
+;** delete crkdown.nv file before 1st time you play game, ok after that **
+crkdown:
+crkdownj:  ;******Crack Down (Japan, FD1094 317-0058-04b)
+crkdownu:
+0:fb246:25:00:18
+
+pwrinst2:
+pwrinst2j:  ;******gouketsuji ichizoku 2 (japan)
+0:40e800:32:00:01
+
+gtmr:
+gtmra:  ;******1000 Miglia: Great 1000 Miles Rally (94/06/13)
+0:102df2:19e:59:80
+
+gtmro:
+gtmrb:
+0:102df2:19a:59:80
+
+gtmre:
+gtmrusa:
+0:1035fa:19e:59:80
+
+wbeachvl2:  ;******World Beach Volley (set 2)
+0:ffbe9a:87:56:00
+0:ffbf1f:1:05:05
+
+;********playmark.c
+wbeachvl:
+wbeachvl3:
+0:ffbfb8:8a:31:00
+
+jollyjgr:  ;******Jolly Jogger
+;** hiscore updates when you start your first game ** 
+0:85c8:3:00:00
+0:85c9:1:50:50
+
+elim2c:  ;******Eliminator (2 Players, cocktail)
+0:c9a0:1e:0c:03
+0:c925:14:00:00
+
+elim4p:  ;******Eliminator (4 Players, prototype)
+0:cc4d:1e:0c:03
+0:c928:14:00:00
+
+bnglngby:  ;******vs. raid on bungeling bay (japan)
+0:6400:5a:00:01
+
+dkngjnrb:  ;******donkey kong jr. (bootleg?)
+dkongjnrj:  ;******donkey kong jr. (japan?)
+dkongjr:  ;******donkey kong jr. (us)
+dkongjre:
+dkongjrpb:
+0:6105:9e:10:10
+0:60b8:3:50:00
+0:7661:1:10:10
+0:7641:1:00:00
+0:7621:1:00:00
+0:7601:1:07:07
+0:75e1:1:06:06
+0:75c1:1:05:05
+0:75a1:1:00:00
+
+dkongjrb:  ;******donkey kong jr. (bootleg)
+dkongjrj:  ;******donkey kong jr. (japan)
+jrking:  ;******Junior King (bootleg of Donkey Kong Jr.)
+dkingjr:
+0:6105:9e:10:10
+0:60b8:3:00:01
+0:7661:1:10:10
+0:7641:1:00:00
+0:7621:1:01:01
+0:7601:1:01:01
+0:75e1:1:08:08
+0:75c1:1:00:00
+0:75a1:1:00:00
+
+dkongjrm:  ;******donkey kong jr. (moon cresta hardware)
+0:6105:9e:10:10
+0:60b8:3:00:01
+0:9261:1:10:10
+0:9241:1:00:00
+0:9221:1:01:01
+0:9201:1:01:01
+0:91e1:1:08:08
+0:91c1:1:00:00
+0:91a1:1:00:00
+
+vspinbal:
+vspinbalj:  ;******vs. pinball (japan)
+0:ba0:10:1c:00
+0:118:5:00:00
+
+searchar:
+searcharu:
+searcharj:  ;******;sar - search and rescue (japan)
+0:437b6:50:00:1f 
+0:40118:3:00:01
+
+jajamaru:  ;******vs. ninja jajamaru kun (japan)
+0:900:5b:22:00
+0:66:3:d0:00
+
+mightybj:  ;******vs. mighty bomb jack (japan)
+0:3a8:4:00:00
+0:3aa:1:10:10
+
+machridrj:  ;******vs. mach rider(japan,fighting cource version)
+machridra:
+0:700:50:00:4b
+0:701:1:05:05
+
+iceclmrj:  ;******vs. ice climber dual (japan)
+iceclmrd:
+0:750:3c:00:23
+0:751:1:77:77
+1:750:3c:00:23
+1:751:1:77:77
+
+iceclimb:
+iceclimbj:  ;******vs. ice climber (japan)
+iceclimba:
+0:750:3c:00:23
+
+vsgradus:  ;******vs. gradius
+0:7e0:3:00:00
+0:7e1:1:50:50
+
+vsfdf:  ;******vs. freedom force
+0:712:9c:10:28
+
+excitebk:
+excitebka:
+excitebkj:  ;******vs. excitebike (japan)
+excitebko:
+0:630:14f:00:0e
+
+vsgongf:  ;******vs. gong fight
+ringfgt:
+ringfgt2:
+0:c026:3:00:00
+0:c060:3e:00:11
+0:c027:1:20:20
+
+vblokbrk:  ;******vs block breaker (asia)
+sarukani:
+0:6027cb8:80:00:2e
+
+vsgshoe:  ;******vs. gumshoe
+0:560:1d:12:a0
+
+tetrisse:  ;******Tetris (Japan, System E)
+0:ccc1:9f:4a:04
+
+ssriders:
+ssridersebd:
+ssridersebc:
+ssridersuab:
+ssridersuda:
+ssridersuac:
+ssridersubc:
+ssridersjbd:
+ssridersabd:
+ssriderseaa:  ;******Sunset Riders (4 Players ver EAA)
+ssridersjac:
+ssridersjad:
+0:104400:50:4b:00
+0:104120:4:00:00
+
+plotting:
+plottingu:  ;******Plotting (US)
+plottinga:
+plottingb:
+flipull:
+0:82b0:30:00:13
+
+mslugx:  ;******metal slug x
+0:10f010:47:00:50
+0:10e8f2:2:ff:ff
+
+mslug2:  ;******metal slug 2
+0:10f00a:61:00:59
+0:10e6f4:2:ff:ff
+
+jin:  ;******jin
+0:a200:3f:30:4e
+
+spatter:
+ssanchan:  ;******sanrin san chan (japan)
+0:ef00:31:00:52
+0:c00b:3:00:00
+0:c00c:1:10:10
+
+vautour2:  ;******Vautour (set 2)
+0:41e0:1:20:20
+0:41c0:1:20:20
+0:41a0:1:20:20
+0:4180:1:20:20
+0:4160:1:20:20
+0:4140:1:20:20
+0:4389:3:00:00
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.99 additions below - by leezer    *
+;***********************************************************************
+
+osman:  ;******osman (world)
+candance:  ;******cannon dancer (japan)
+0:186f80:ee:93:00
+0:187068:1:01:01
+
+magdropp:  ;******magical drop plus 1 (japan, version 2.1 1995.09.12)
+0:6800c4:45:00:41
+0:680920:a:54:00
+
+magdrop:  ;******Magical Drop (japan, version 1.1 1995.06.21)
+0:3800c4:45:00:41
+0:380920:a:54:00
+
+chainrec:  ;******Chain Reaction (world, version 2.2 1995.09.25)
+0:4000c0:4d:00:41
+0:400920:a:54:00
+
+cannonb:
+cannonb2: 
+cannonb3: 
+0:6180:d4:00:01
+0:665c:3:00:01
+
+cannonbp:
+0:4d80:df:00:01
+
+prtytime:  ;******Party Time: Gonta the Diver II
+gangonta:  ;******Ganbare! Gonta!! 2
+0:185c24:4d:00:18
+0:201bd0:27:32:00
+0:201bf4:1:05:05
+
+joemacr:  ;******Joe & Mac Returns 
+joemacra:  ;******Joe & Mac Returns (set 2)
+joemacrj:
+0:1000c0:9d:01:09
+0:20105c:3:a0:01
+
+enduror:
+enduror1:  ;******Enduro Racer (YM2203, FD1089B 317-0013A)
+enduror1d:
+endurord:
+0:43400:4a0:01:20
+0:43b90:10:99:99
+
+kaitei:  ;******kaitei takara sagashi (k`k-tokki) 
+0:200e:5:00:00
+
+kaitein:  ;******kaitei takara sagashi  
+0:403e:2:00:00
+0:21c0:1:00:00
+0:21e0:1:00:00
+0:2200:1:ec:ec
+0:2240:1:ec:ec
+0:2220:1:ec:ec
+0:2260:1:ec:ec
+
+loffire:  ;******line of fire / bakudan yarou (world, fd1094 317-0136)
+loffireu:  ;******Line of Fire / Bakudan Yarou (US, FD1094 317-0135)
+loffirej:  ;******Line of Fire / Bakudan Yarou (japan, FD1094 317-0134)
+loffired:
+loffirejd:
+loffireud:
+0:a3800:18f:01:49
+
+;******lethal enforcers II:gun fighters (ver uaa)
+le2u:
+0:c03e94:40:05:48
+
+;******lethal enforcers (us ver uae)
+lethalen:
+lethalenub:
+0:3390:50:41:00
+0:33de:1:70:70
+
+;******born to fight
+borntofi:
+0:166:8b:50:0b
+
+sandscrp:
+sandscrpa:  ;******Sand Scorpion (set 2)
+sandscrpb:
+0:702014:50:00:1b
+0:700048:4:00:00
+
+;********arabian (fixed)
+arabian:
+arabiana:
+0:d384:3c:00:00
+0:d3bd:1:01:01
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.98 additions below - by leezer    *
+;***********************************************************************
+
+;******Gun Master
+gunmast:
+0:80e308:4b:00:ae
+
+;******Tenkomori Shooting (TKM2/VER.A1)
+tenkomor:
+tenkomorj:
+0:3fd60:c7:20:2d
+
+;******slipstream
+slipstrm:
+slipstrmh:
+0:2095e1:4e3:60:4d
+0:2037cf:5c:01:4d
+
+mechatt:
+mechattu:  ;******Mechanized Attack (US)
+mechattj:
+0:7f943:3:02:54
+0:7f9bb:99:02:14
+
+mechattu1:
+0:7f943:3:00:15
+0:7f9bb:99:00:2e
+
+metrocrs:  ;******metro-cross (set 1)
+metrocrsa:  ;******metro-cross (set 2)
+0:1471:7b:2b:0e
+0:1423:3:00:00
+0:486c:7:2d:00
+
+;******action hollywood
+actionhw:
+0:ff5a2a:28:4a:01
+
+;******Animalandia Jr.
+animaljr:
+0:67a3:a:00:22
+0:6b63:1:08:08
+
+finalap2:
+finalp2j:  ;******final lap 2 (japan)
+0:106000:d0:50:01
+
+finalap3:
+finalp3j:  ;******Final Lap 3 (Japan)
+0:106000:d0:4d:19
+
+eaglshot:  ;******eagle shot golf
+eaglshta:  ;******eagle shot golf (alt)
+0:20:62:48:18
+
+rdft:
+rdftau:
+rdftj:  
+rdftadi:  ;******Raiden Fighters (Dream Island Co. license)
+rdftu:  ;******Raiden Fighters (US)
+rdfta:
+rdftdi:
+rdftit:
+rdfts:
+rdftauge:
+rdftja:
+rdftjb:
+0:29bc1:aa:40:4f
+
+mrkougar:
+mrkougb:
+mrkougb2:  ;******Mr. Kougar (bootleg Set 2)
+mrkougar2:  ;******mr.kougar (earlier)
+0:40a6:12:00:00
+0:4a61:1:10:10
+0:4a41:1:10:10
+0:4a21:1:10:10
+0:4a01:1:10:10
+0:49e1:1:10:10
+0:49c1:1:10:10
+
+ladybug:
+ladybugb:
+ladybgb2:  ;******Lady Bug (bootleg Set 2)
+0:6073:1b:01:00
+0:d380:75:ff:ff
+
+ladybugg:
+0:5884:64:01:47
+
+;******n-sub (upright)
+nsub:
+0:8397:2:00:00
+
+;******Falcon (bootleg set 2)
+falcona:
+0:4389:3:00:00
+0:4140:1:20:20
+0:4160:1:20:20
+0:4180:1:20:20
+0:41a0:1:20:20
+0:41c0:1:20:20
+0:41e0:1:20:20
+
+;******a.d. 2083
+ad2083:
+0:4600:64:0a:04
+0:40a8:3:00:06
+
+welltris:  ;******welltris (world?,2 players)
+welltrisj:  ;******welltris (japan,2 players)
+0:ffb61c:50:0c:00 
+
+mshuttle:
+mshuttlej:
+mshuttlej2:  ;****** Moon Shuttle (Japan set 2)
+mshuttle2:
+0:808a:58:00:24
+
+wexpress:
+wexpressb:
+wexpressb2:
+wexpressb3:
+wexpressb1:
+0:0245:3:15:00
+0:0240:50:20:00
+
+exprraida:  ;******Express Raider (US set 2)
+exprraidi:
+0:0240:50:20:00
+
+;********exprraid.c
+exprraid:
+exprraidu:
+0:05fd:3:15:00
+0:0240:50:20:00
+
+yosakdon:
+yosakdona:  ;******yokasu to donbei (set 2)
+0:23ab:3:00:00
+
+;*******Yellow Cab (bootleg)
+;** you must exit this game when either the main title page is showing **
+;** (the screen with the game name and copyright displaying) or when the hiscore **
+;** is being displayed in attract mode, or the save will not work **
+kamikcab:
+yellowcb:
+yellowcj:  ;******Yellow Cab (Japan)
+0:636b:7c:00:20
+
+;******hyper crash (version d)
+hcrash:
+hcrashc:  ;******Hyper Crash (version C)
+0:81900:ac5:00:10
+0:80e88:4:00:70
+0:80e94:4:00:70
+0:80c64:1:20:20
+
+gaiapols:
+gaiapolsj:  
+gaiapolsu:
+0:60f801:99:00:00
+0:60f896:1:29:29
+
+;******space position (japan)
+spcpostn:
+0:c000:172:00:02
+0:cfe9:64:ff:ff
+
+;******gardia
+gardia:
+gardiab:
+gardiaj:
+0:d300:50:00:4a
+0:c017:3:00:02
+
+rdft22kc:
+rdft2a:  
+rdft2:  ;******Raiden Fighters 2 
+rdft2j: 
+rdft2a2:
+rdft2us:  ;******raiden fighters 2.1 (us, single board)
+rdft2j2:
+rdft2t:
+rdft2u:
+rdft2aa:
+rdft2ja:
+0:285dc:1ab:01:2e
+
+brival:
+brivalj:  ;*******(burning rival (japan)
+0:208300:4a:42:04
+
+kikcubic:
+kikcubicb:  ;******Kickle Cubele
+0:fe30:c8:07:04
+0:fef8:3:07:35
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.96 additions below - by leezer    *
+;***********************************************************************
+
+;******Schmeiser Robo (japan)
+schmeisr:
+0:ff5a20:79:00:4c
+
+;******joinem
+joinem:
+0:8bad:5a:00:43
+
+;******calorie kun vs moguranian
+calorie:
+calorieb:  ;******calorie kun vs moguranian (bootleg)
+0:cd11:78:00:49
+0:c418:3:00:01
+
+;******Pachinko Sexy Reaction 2 (Japan)
+sxyreac2:
+0:7550:a3:4c:4c
+
+survarts:  
+survartsu:  ;******survival arts (usa)
+0:11a5:26:00:45 
+0:11cb:2:45:00
+
+invaders:
+earthinv:
+spaceatt:
+spaceat2:
+sinvemag:
+sitv:
+sicv:
+sisv:
+sisv1:
+sisv3:
+sisv2:
+alieninvp2:
+spceking:
+spcewars:
+spacewr3:
+invader4:  
+invadrmr:  
+invasion:
+searthin:
+searthina:
+superinv:
+sinvzen:
+invasiona:
+invasionb:
+invasionrz:
+invasionrza:
+spacerng:
+ultrainv:
+spacecom:
+sitvo:
+sitv1:
+invadersem:
+galmonst:
+spaceatt2k:
+spaceattbp:
+0:20f4:02:00:00
+
+searthie:
+0:20f4:02:00:50
+
+alieninv:
+0:20f4:2:00:50
+
+invaderl:
+0:20E0:03:00:00
+
+sspaceatc:
+sspaceat:
+sspaceat2:
+sspaceat3:
+0:c4c7:10:00:00
+
+;******Cosmic Monsters 2
+cosmicm2:
+cosmicmo: ;******cosmic monsters (*) 
+0:20f4:03:00:00
+
+darthvdr:
+0:1c08:2:00:00
+
+jspecter:
+jspecter2:
+0:20f4:2:00:00
+0:2300:2:00:00
+
+;******diet go go (euro v1.1 1992.09.26)
+dietgo:
+dietgoe:  ;******(euro v1.1 1992.08.04)
+dietgoj:  ;******(japan v1.1 1992.09.26)
+dietgou:  ;******(usa v1.1 1992.09.26)
+0:3801f8:4:00:00
+0:380100:ef:48:50
+0:3801f9:1:35:35
+
+ambushj:
+ambush:   ;******ambush (tecfry)
+ambushv:  ;******ambush (Volt Elec co-ltd)
+ambushh:
+0:8050:3:00:00
+0:800f:24:00:3a
+
+;******g-loc air battle (us)
+;** you need to press f3 as soon as this game starts before it will save **
+;** for some reason the hiscore data will not display untill game is reset with f3 **
+;** driver problem ??????  **
+glocu:
+gloc:
+2:1ffa00:ee:02:04
+2:1ffa4a:1:50:50
+
+;******Beach Festival World Championship 1997
+wbbc97:
+0:5023f1:6d:00:02
+
+opwolf:  
+opwolfb:
+opwolfu:
+opwolfa:
+opwolfj:  
+0:100a42:75:00:54
+0:100e28:3b:00:01
+
+opwolfp:
+0:100a6a:75:00:54
+0:100e68:37:08:01
+
+gsword:  ;******Great Swordsman (Japan?)
+gsword2: ;******Great Swordsman (world?) 
+0:9c00:1e:00:00
+0:9c78:3c:34:00
+
+;******Flying Tiger
+flytiger:
+flytigera:
+0:d244:34:88:48
+0:d235:1:03:03
+
+mcatadv:
+catt:  ;******Catt (Japan)
+mcatadvj:
+0:101bd3:31:05:2b
+
+avalnche:
+cascade:  ;******Cascade 
+0:009b:2:00:00
+
+;******Aero Fighters (bootleg)
+aerfboot:
+aerofgtb:  ;******aero fighters (turbo force hardware set 1)
+aerofgtc:  ;******aero fighters (turbo force hardware set 2)
+aerfboo2:
+0:cc1af:97:0b:64
+
+triothepj:
+triothep:  ;******Trio The Punch - Never Forget Me... (World)
+0:1f1a58:41:41:4d
+
+simpsons:
+simpsons2pj:
+simpsons2p:
+simpsons4pa:  ;******The Simpsons (4 Players alt)
+simpsons2p2:  ;******the simpsons (2 player alt)
+simpsons2pa:
+simpsons2p3:
+0:4980:50:42:00
+
+;******Dr. Tomy
+drtomy:
+0:ffee00:c0:20:30
+
+pbaction:
+pbaction2:
+pbaction3:  ;******Pinball Action (set 3, encrypted?)
+pbaction4:
+pbaction5:
+0:c093:51:07:00
+0:c12f:27:48:4b
+
+rainbow:
+rainbowo:  ;******rainbow islands (old version)
+rbisland:
+0:10d0cc:32:00:32 
+0:10e1f2:04:00:00 
+
+jumping:
+jumpinga:
+jumpingi:
+0:10d0cc:32:00:41 
+0:10e1f2:04:00:00 
+
+rainbowe:
+rbislande:
+0:10d0d2:32:00:33 
+0:10e1b6:04:00:00
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.95 additions below - by leezer    *
+;***********************************************************************
+
+pclubys:
+pclubysa:  ;******Puzzle Club (Yun Sung - set 2)
+0:20b461:145:3a:64
+0:20e835:b9:38:64
+0:206935:ed:14:64
+0:20b515:91:38:64
+
+;******Hook (Japan)
+hookj:
+0:ea6b7:ec:00:4f
+
+;******Big Kong
+bigkong:
+0:6109:a1:00:92
+0:60b8:3:50:00
+
+;******mighty monkey (bootleg on scramble hardware)
+;** very dodgy hiscore saving, possibly because of it been a **
+;** poorly put together bootleg **
+mimonscr:
+0:44a1:2:d0:07
+0:4981:1:00:00
+0:49a1:1:00:00
+0:49c1:1:00:00
+0:49e1:1:00:00
+0:4a01:1:02:02
+0:4a21:1:10:10
+0:4a41:1:10:10
+0:4920:1:10:10
+0:4940:1:10:10
+0:4960:1:15:15
+0:4980:1:22:22
+0:49a0:1:1f:1f
+0:49c0:1:13:13
+0:49e0:1:23:23
+0:4a00:1:10:10
+0:4a20:1:18:18
+0:4a40:1:17:17
+0:4a60:1:19:19
+0:4a80:1:18:18
+0:4aa0:1:10:10
+0:4ac0:1:10:10
+0:4ae0:1:10:10
+
+;******mighty monkey
+mimonkey:
+mimonsco:  ;******mighty monkey (bootleg on super cobra hardware)
+0:84a1:2:d0:07
+0:8981:1:00:00
+0:89a1:1:00:00
+0:89c1:1:00:00
+0:89e1:1:00:00
+0:8a01:1:02:02
+0:8a21:1:10:10
+0:8a41:1:10:10
+0:8920:1:10:10
+0:8940:1:10:10
+0:8960:1:15:15
+0:8980:1:22:22
+0:89a0:1:1f:1f
+0:89c0:1:13:13
+0:89e0:1:23:23
+0:8a00:1:10:10
+0:8a20:1:18:18
+0:8a40:1:17:17
+0:8a60:1:19:19
+0:8a80:1:18:18
+0:8aa0:1:10:10
+0:8ac0:1:10:10
+0:8ae0:1:10:10
+
+disco:
+discof:  ;******disco no.1 (rev f)
+0:0400:24:00:00
+0:0006:3:00:00
+
+;******Cookie & Bibi
+cookbib:
+cookbiba:
+0:121cca:aa:20:64
+
+;(bull fighter) (by GeoMan)
+bullfgtr:
+bullfgtrs:  ;******Bull Fighter (Sega)
+0:40700:40:41:00
+0:40012:6:00:00
+0:800b0:1c:00:11
+
+bigstrik:
+bestleag:  
+bestleaw:
+bigstrkb:
+0:ff890b:49:08:78
+
+bigstrkba:
+0:ff890b:49:00:78
+
+;******Snapper (Korea)
+snapper:
+0:ff3521:26:01:05
+
+;*******holeland.c (crazy rally)
+crzrally:
+crzrallyg:  ;******Crazy Rally (Gecas license)
+crzrallya:
+0:c000:36:00:41
+
+;******Buccaneers (set 2)
+buccanrsa:
+0:e36d:46:20:4f
+
+buccanrs:  ;******Buccaneers (set 1)
+0:e36e:46:20:4f
+
+buccanrsb:
+0:e373:46:20:4f
+
+;*********(defender (red label))
+;*** this saves just the today`s best scores, the all time greatest are ***
+;*** saved using nvram ***
+defender:
+startrkd:  
+defenderg:  
+defenderw:  
+defenderb:  ;******defender (blue label)
+defence:
+defcmnd:
+0:b260:60:00:48
+
+tornado1:
+zero:
+zero2:
+0:b260:60:00:58
+
+;(sky lancer) (by GeoMan)
+skylancr:
+skylancre:  ;******sky lancer (esco trading co licence)
+0:82e3:2:00:01
+0:82e5:22:00:00
+
+;********pinbo.c (pinbo & pinbo (strike))
+pinbo:
+pinbos:
+pinboa:  ;******Pinbo (set 2)
+0:120:6e:24:00
+0:43:3:00:00
+0:44:1:50:50
+
+;******Star Fire 2
+starfir2:
+0:82a9:6a:00:00
+
+;******star fire (set 2)
+starfirea:
+0:82ba:aa:00:00
+
+;******Excelsior 
+excelsr:
+0:ff1778:b3:0c:01
+
+excelsra:
+0:ff1780:b3:0c:01
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.94 additions below - by leezer    *
+;***********************************************************************
+
+;******galaxy force 2
+gforce2:
+gforce2j:  ;******galaxy force 2 (japan)
+gforce2ja:
+2:1fe400:38:00:01
+
+;******power drift
+pdrift:
+pdriftj:  ;******power drift (japan)
+pdrifta:
+pdrifte:
+2:1ffa16:18f:02:08
+
+;******Viper Phase 1 (japan,new version)
+viprp1:
+viprp1s:  ;******Viper Phase 1 (Switzerland, New Version)
+viprp1j:
+viprp1u:
+viprp1k:
+viprp1h:
+0:1e610:c7:40:2e
+
+viprp1oj:  ;******Viper Phase 1 (japan)
+0:1d7b9:c7:20:2e
+
+viprp1ot:  ;******Viper Phase 1 (Germany)
+viprp1hk:
+0:1e600:c7:40:2e
+
+;******Ring King (US, Woodplace license)
+ringkingw:
+1:8048:8C:00:12
+0:C22a:04:00:05
+
+;******Surprise Attack (Asia ver. L)
+suratk:
+suratkj:
+suratka:
+0:b00:5a:11:31
+0:5981:3:10:00
+0:609e:6:01:00
+
+;******Alpha Mission
+alphamis:
+0:d83b:82:00:20
+0:e77b:3:00:00
+
+;********sprcros2.c 
+sprcros2:
+sprcros2a:  ;******Super Cross 2 (Japan set 2)
+0:fa00:78:00:4a
+0:f012:6:00:00
+0:f013:1:03:03
+
+;******ufo senshi yohko chan
+ufosensi:
+ufosensb: ;******Ufo Senshi Yohko Chan (not encrypted)
+0:c800:62:11:41
+
+altbeast:
+altbeast2:
+altbeastj3:  ;******altered beast (japan, fd1094 317-0068)
+altbeast4:  ;******altered beast (set 4, mc-8123b 317-0066)
+altbeast5:  ;******altered beast (set 5, 8751 317-0076)
+altbeastj:  ;******altered beast (set 6, japan, 8751 317-0077)
+altbeastj1:  ;******altered beast (set 1, japan, fd1094 317-0065)
+altbeast6:
+altbeastbl:
+altbeast5d:
+altbeastj3d:
+0:fffc00:74:00:33
+0:fff010:4:00:00
+
+;******lunar battle (prototype,later)
+lunarbat:
+0:42b:2d:50:03
+
+;******rack + roll
+racknrol:
+0:1db8:45:23:13
+
+gravitar:
+gravitar2:
+gravp:  ;******gravitar (prototype)
+gravitar1:
+0:41e:30:50:05
+
+;********missile.c
+missile2:
+suprmatk:
+missile:
+suprmatkd:  ;******super missile attack (not encrypted)
+0:002c:30:47:00
+
+;(missile command (set 2)) clone (by GeoMan) - modified hiscore save
+missile1:
+0:002c:30:4D:00
+
+;*******wall crash
+wallc:
+wallca:  ;******Wall Crash (set 2)
+brkblast:
+0:a200:28:00:01
+0:a284:4:00:00
+
+;******Space Guerilla
+spaceg:
+0:7007:3:00:00
+
+rezon:
+rezont:  ;******Rezon (Taito)
+0:201c66:63:03:20
+0:2018ba:2:03:e8
+
+;********pushman.c 
+pushman:
+pushmans:
+pushmana:  ;******Pushman (Korea, set 2)
+pushmant:
+0:ffc690:50:00:41
+0:ffcc2a:4:00:00
+
+lgtnfght:
+trigon:
+lgtnfghtu:  ;******lightning fighters (us)
+lgtnfghta:
+0:90400:50:41:50
+0:90120:4:00:60
+
+;******Bronx 
+bronx:
+0:e1da:28:0:41
+
+;********aerofgt.c (karate blazers (world? & us))
+karatblz:
+karatblzu:
+karatblzj:  ;******Karate Blazers (Japan)
+karatblzbl:
+karatblza:
+0:c5ba7:31:00:20
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.91 additions below - by leezer    *
+;***********************************************************************
+
+;******Kick Boy
+kickboy:
+0:9338:3:88:02
+0:9340:23:88:54
+
+;******Dacholer
+dacholer:
+0:933c:23:88:54
+0:9334:3:88:02
+
+;*******clshroad.c (clash road)
+clshroad:
+clshroads:  ;******Clash-Road (Status license)
+clshroadd:
+0:8000:3c:4d:00
+0:803a:1:40:40
+
+;********pacman.c (van van car)
+vanvan:
+vanvank:  ;******van-van car (karateco)
+vanvanb:  ;******Van-Van Car (set 3)
+0:4809:6:00:00
+0:4c60:f0:00:00
+
+;shot rider (by tamphax)
+shtrider:
+shtridera:  ;******shot rider (sigma license)
+shtriderb:
+0:e013:2d:00:4d
+
+;********othunder.c (operation thunderbolt)
+othunder:
+othunderu:
+othunderj:  ;******Operation Thunderbolt (Japan)
+othunderuo:  ;******Operation Thunderbolt (us,older)
+0:839ca:438:4e:00
+0:83dd9:1:01:01
+
+;******Great 1000 Miles Rally 2 USA (95/05/18)
+gtmr2u:
+0:103b34:b62:59:01
+
+;********popeye.c (popeye bootleg fixed)
+popeyebl:
+0:8200:24:00:02
+0:8fed:3:00:03
+0:8f32:6:00:00
+
+;******super volley (japan)
+svolley:
+svolleyk:
+svolleyu:
+0:60512:48:00:05
+
+popeyef:
+0:8a00:24:00:01
+0:8fed:3:00:02
+0:8f32:6:00:00
+
+;********popeye.c (popeye (revision d & revision d not protected & revision f))fixed
+popeye:
+popeyeu:
+0:8a00:24:00:02
+0:8fed:3:00:03
+0:8f32:6:00:00
+
+;Puzzle Bobble (Japan, B-System) - (By Andrea Trasatti)
+pbobble:
+0:907010:36:00:00
+
+;******turbo out run (set 2, upright, 317-unknown)(both fixed) 
+toutruna:
+toutrunu:  ;****** turbo out run (set 3,upgrade kit, 317-0118)
+toutrun1:
+toutrun2:
+toutrun:
+toutrun3:
+toutrunj:
+toutrunj1:
+toutrun3d:
+toutrund:
+toutrunj1d:
+toutrunjd:
+toutrun2d:
+0:6046e:118:05:20
+0:60909:1:09:09
+
+;*********neogeo.c (Twinkle Star Sprites)
+twinspri:
+0:10bcff:7d:00:00
+0:10bb74:02:ff:ff
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.90 additions below - by leezer    *
+;***********************************************************************
+
+;alexkida:
+alexkidd:  ;******alex kidd: the lost stars (set 1,fd1089a -unknown)
+alexkidd1:
+0:fffc00:38:00:44
+0:fff010:4:00:00
+
+;******action fighter (fd1089a 317-0018)
+afighter:
+0:fff300:50:00:59
+0:ffc060:4:00:00
+0:ffc061:1:06:06
+
+;******dunk shot (fd1089 317-0022)
+dunkshot:
+dunkshoto:
+dunkshota:
+0:ff31c0:874:49:01
+
+;*********(Quiz Sangokushi (Japan))
+qsangoku:
+0:e815:4b:00:00
+0:e860:03:01:00
+
+;*********(Shippu Mahou Daisakusen (Japan))
+shippumd:
+kingdmgp:
+0:1002d0:9e:00:4e
+0:1003c4:53:2a:39 
+
+;********cps2.c (Quiz Nanairo Dreams: Nijiirochou no Kiseki (Japan 960826))
+qndream:
+0:ff40b3:d8:00:00
+0:ff418b:02:01:00
+
+;*********(Sonic Wings (Japan))
+sonicwi:
+0:cc1af:a0:0b:00
+
+;*********scobra.c (tazz-mania)
+tazmania:
+tazmani2:
+tazzmang:  ;******Tazz-Mania (Galaxian Hardware)
+tazzmang2:
+0:80ef:3c:01:4c
+
+;******riot
+riot:
+0:101d3c:f0:64:18
+
+;******thunder blade (fd1094 317-0056)
+thndrbld:
+thndrbld1:  ;******thunder blade (japan)
+thndrbldd:
+0:a3b00:64:01:01
+
+;********segac2.c (bloxeed (c system))
+bloxeedc:
+bloxeedu:
+bloxeed:  ;******bloxeed (japan,fd1094 317-0139)
+bloxeedd:
+0:fff40a:64:53:08
+0:fff082:1:01:01
+
+;********sf1.c
+;sf:  ;******street fighter (world)
+sfan:
+0:ff94f2:9C:00:12
+0:ff8732:8:00:00
+
+sfj:
+sfu:
+sf:
+sfua:
+0:ff8e72:9C:00:12
+0:ffc012:8:00:00
+
+sfp:
+0:ff9498:9C:00:12
+0:ff8d18:8:00:00
+
+wrestwar:
+wrestwar1:  ;******Wrestle War (FD1094, 317-0102)
+wrestwar2:
+wrestwar1d:
+wrestwar2d:
+0:fff800:a0:00:a0
+0:ffe044:4:00:00
+
+;******Desert Breaker (FD1094 317-0196)
+dbrkr:
+0:ff3418:1:1a:1a
+0:ff3b02:4:00:e8
+0:ffbb02:4:00:e8
+0:fffb02:4:00:e8
+0:ff7b02:4:00:e8
+
+;******Racing Hero (FD1094 317-0144)
+rachero:
+racherod:
+0:ff89be:51:10:01
+0:ff89ae:4:10:00
+
+;********bloodbro.c
+bloodbro:
+weststry:
+bloodbroa:  ;******Blood Bros. (set 2)
+bloodbrob:
+0:85b1f:f9:30:00
+0:85c15:1:02:02
+
+;******scorpion (set 1)
+scorpion:
+scorpionmc:  ;******scorpion (moon cresta hardware)
+scorpiona:  ;******Scoprion (set 2)
+scorpionb:
+aracnis:
+0:4207:f:00:00
+0:42ad:f:10:10
+
+;*******steel gunner
+sgunner:
+sgunnerj:  ;******Steel Gunner (Japan)
+0:10018f:bb:00:4f
+0:100165:b:00:00
+0:100169:1:04:04
+
+;*******namcos2.c (ordyne (japan))
+ordynej:
+ordyne:  ;******Ordyne (Japan)
+0:100712:28:00:03
+0:40925c:4:00:00
+
+;********(lucky & wild)
+luckywld:
+luckywldj:  ;******Lucky & Wild (Japan)
+0:100b00:a0:00:02
+
+huncholy:
+hncholms:  ;******Hunchback Olympic (Scramble hardware)
+0:3c08:12:00:30
+
+herbiedk:
+0:3c22:1b:00:00
+0:3c20:1:18:18
+
+;********system16.c (flash point (bootleg))
+fpointbl:
+fpointbj:  ;******flash point (japan,bootleg)
+0:ffec6e:64:00:00
+0:fff000:910:00:00
+0:ffe083:1:33:33
+
+fpoint:
+fpoint1d:
+fpointd:
+0:ffec6d:65:08:01
+0:fff000:910:00:00
+0:ffe083:1:33:33
+
+fpoint1:
+0:ffec6d:65:08:01
+0:fff000:910:00:00
+0:ffe083:1:33:33
+
+;******michael jacksons moonwalker (world,fd1094/8751 317-0159)
+mwalk:
+mwalku:  ;******michael jacksons moonwalker (us,fd1094/8751 317-0158)
+0:ff3c00:50:00:4a
+0:ffe020:4:00:00
+
+mwalkj:
+0:ff3c00:50:00:4a
+0:ffe020:4:00:00
+
+mwalkbl:
+mwalkd:
+mwalkjd:
+mwalkud:
+0:fffc00:50:00:4a
+0:ffe020:4:00:00
+
+aurail:
+auraila:  ;******aurail (set 2,fd1089? 317-unknown)
+aurailj:
+aurail1d:
+aurailjd:
+0:ffff7e:27:00:52
+
+;******body slam (8751 317-unknown) 
+bodyslam:
+dumpmtmt:  ;******dump matsumoto (japan 8751 317-unknown)
+0:fffcc0:3c:00:00
+0:fffcfa:1:03:03
+
+;Golden Axe (by GeoMan)
+goldnaxe:
+goldnaxa:  
+goldnaxej:  
+goldnaxeu:
+goldnaxeb2: 
+goldnaxeb1:
+goldnaxe1:
+goldnaxe2:
+goldnaxe3:
+goldnaxe1d:
+goldnaxe3d:
+goldnaxejd:
+goldnaxeud:
+0:fffc00:38:02:00
+
+;*******system16.c (dynamite dux (bootleg))
+dduxbl:
+ddux:  ;******dynamite dux (fd1094 317-0096)
+dduxj:
+dduxd:
+dduxjd:
+0:fff880:98:00:20
+0:fff31b:1:03:03
+
+;******cotton (fd1094 317-0181a)
+;** not working yet (driver issue ????) **
+cotton:
+cottonj:
+cottonu:
+cottonja:
+cottond:
+cottonjad:
+cottonjd:
+cottonud:
+0:200076:31:00:55
+0:2000b6:4:00:a0
+
+eswat:
+eswatbl:
+eswatu:  ;******e-swat - cyber police (us,fd1094 317-0129)
+eswatj:  ;******E-Swat - Cyber Police (Japan, FD1094 317-0128)
+eswatj1:
+eswatd:
+eswatj1d:
+eswatjd:
+eswatud:
+0:ffcc00:46:00:00
+0:ffcc42:1:2e:2e
+
+;quartet sets highscore table updated after it displays in attract mode
+quartet:
+quarteta:
+quartet2a:
+quartet2:  ;******quartet 2 (japan, 8751 317-unknown)
+0:ffc400:317:00:44
+0:ff00b9:1:77:77
+
+;***********************************************************************
+;*    latest unofficial highscore_v0.89 additions below - by leezer    *
+;***********************************************************************
+
+;********rockola.c (vanguard)
+vanguard:
+vanguardc:
+vanguardj:  ;******Vanguard (Japan)
+0:220:70:11:30 
+0:25:3:00:00
+
+;********tigeroad.c
+tigeroad:
+toramich:
+tigeroadb:  ;******Tiger Road (us bootleg)
+tigeroadu:
+0:ffec70:64:59:bc
+0:ffc092:4:00:00
+
+;*******wwfwfest.c (wwf wrestlefest (us))
+wwfwfest:
+wwfwfestj:  ;******www wrestlefest (japan)
+wwfwfestb:  ;******www wrestlefest (us bootleg)
+wwfwfesta:  ;******www wrestlefest (us tecmo)
+0:1c00c2:84:08:01
+
+;********combatsc.c by (GoKu)
+bootcamp:
+bootcampa:
+0:1320:46:02:07
+0:826:3:00:10
+
+;*******mermaid.c (mermaid)
+mermaid:
+yachtmn:  ;******Yachtsman 
+0:c008:6:00:00 
+
+;********asteroid.c
+asteroid:
+asteroidb:
+asteroid2:
+hyperspc:
+aerolitos:
+spcrocks:
+0:001d:35:00:00
+
+asteroid1:
+0:001c:35:00:00
+0:2a6:1:01:01
+
+meteorts: ;******Meteorites 
+meteorho:
+0:001c:35:00:00
+
+;******bonk`s adventure
+bonkadv:
+0:1032e0:5c:00:00
+0:10634b:37:60:50
+0:1032f7:1:80:80
+
+;******************************************************************************************
+;* latest unofficial highscore_v0.88 additions below - by leezer/firebrand/geoman/others  *
+;******************************************************************************************
+
+superman:
+supermanu:
+supermanj: ;******Superman (Japan)
+0:f02953:3a:00:49
+0:f0251f:9:20:30
+0:f01cf3:3:00:88
+
+;(bubble 2000) (by GeoMan)
+bubl2000:
+hotbubl: ;******Hot Bubble
+hotbubla:
+0:3c0600:50:00:20
+
+;********brkthru.c
+brkthru:
+brkthruj:
+forcebrk: ;******Force Break (Japan)
+0:0531:27:00:32
+0:0402:3:00:50
+
+;******twin brats (hiscore.dat causes crash at the mo (mame 0.134u3))
+;twinbrat:
+;twinbrata:
+;0:11200e:3c:00:20
+
+;******twins
+twins:
+0:4cc0:60:09:00
+0:4d1d:1:01:01
+
+twinsa:
+0:4cbe:60:09:00
+0:4d1b:1:01:01
+
+;******field combat
+fcombat:
+0:c600:a:00:00
+0:c700:23:00:00
+
+;******mighty warriors
+mwarr:
+0:112002:3d:00:4e
+
+;******Sonic Boom
+sonicbom:
+sonicbomd:
+0:ffc088:4:00:00
+0:ffc100:9e:20:20
+
+;******Explosive Breaker
+explbrkr:
+0:10c01a:63:00:4e
+
+;******Pop Bingo
+;** you cant tenter any names into hiscore table yet, driver problem ??? **
+popbingo:
+0:41001:7f:10:40
+
+;******Space Raider
+sraider:
+0:6010:9f:00:21
+
+;(ginga ninkyouden) (by GeoMan)
+ginganin:
+ginganina:  ;******Ginga NinkyouDen (set 2)
+0:20291:50:00:59
+0:202e1:83:20:09
+0:2011d:3:00:00
+
+sonofphx:
+99lstwar:
+99lstwra:
+repulse:
+99lstwark:  ;******'99: The Last War (Kyugo)
+0:f660:5f:00:ff
+
+;********pengo.c
+pengo:
+pengob: ;******pengo (bootleg)
+penta:
+pengojpm:
+pengopac:
+0:8840:1e:d0:41
+0:880c:2:d0:07
+
+;******pengo (set 3 not encrypted)
+pengo3u:
+0:8840:1e:d0:4d
+0:880c:2:d0:07
+
+pengo2:
+pengo2u:
+pengo4: ;******Pengo (set 4)
+0:8840:1e:00:4d
+0:880c:2:00:00
+
+;********rockola.c
+nibbler:
+nibblerp:
+nibbler8:
+nibbler6:
+nibblero: ;******Nibbler (Olympia)
+0:0290:28:00:00
+0:02d0:1e:13:14
+
+;(ikki (japan)) (by GeoMan)
+ikki:
+farmer: ;*****Farmers Rebellion
+0:c010:1e:22:00
+0:d61b:1:2a:2a
+0:d65b:1:04:04 
+0:d69b:1:00:00 
+0:d6db:1:00:00
+0:d71b:1:00:00
+0:d75b:1:00:00
+
+;******Crazy Climber 2 (Japan Harder)
+cclimbr2a:
+0:612a7:49:10:00
+0:612f2:1:50:50
+
+;******Painted Lady (Splash) (Ver 1.3 US)
+paintlad:
+0:ffca10:50:00:00
+0:ffca5e:1:27:27
+
+;******************************************************************************************
+;* latest unofficial highscore_v0.87 additions below - by leezer/firebrand/geoman/others  *
+;******************************************************************************************
+
+;******Wizz Quiz (version 4)
+wizzquiz:
+0:2b4f:221:4d:00
+0:2d6e:1:05:05
+
+;******miss bingo
+msbingo:
+0:101288:a:09:30
+0:1000c2:31:4d:20
+
+;******cookie & bibi 2
+cookbib2:
+0:1026a2:28:4b:00
+0:1026c4:1:4d:4d
+
+;******Street Fighter II' - Hyper Fighting (World 921209)
+sf2hf:   
+0:ffd276:28:00:20
+0:ffd2c6:14:ff:96
+0:ffd2ee:04:00:00
+
+;*******Fighting Basketball
+fghtbskt:
+0:c0c0:28:03:dd
+
+;*******Pairs (Nichibutsu) (Japan 890822)& pairs (system ten)(japan 890826)
+pairsten:
+pairsnb:
+0:f832:3:70:00
+0:f814:1:03:03
+
+;******************************************************************************************
+;* latest unofficial highscore_v0.86 additions below - by leezer/firebrand/geoman/others  *
+;******************************************************************************************
+
+;*******drakton
+drakton:
+drktnjr:
+0:6449:118:00:00
+0:655d:1:20:20
+
+;*******Robo Wres 2001 & bootleg
+robowres:
+robowresb:
+0:e01a:7:00:00
+0:e370:73:00:00
+
+;*******Field Goal
+fgoal:
+fgoala:
+0:89:9:00:00
+
+;*******Virtua Fighter 1
+vf1:
+vf:
+0:40f800:b3:09:4d
+
+;*******The Return of Lady Frog & The Return of Lady Frog (set 2)
+roldfrog:
+roldfroga:
+0:ffca10:50:00:00
+0:ffca5b:1:0f:0f
+
+;*******counter Run (bootleg set 1)
+countrunb:
+0:d0d8:127:00:48
+
+;******************************************************************************************
+;* latest unofficial highscore_v0.85 additions below - by leezer/firebrand/geoman/others  *
+;******************************************************************************************
+
+;*******gold medalist & Gold Medalist (alt) 
+goldmedl:
+goldmedla:
+0:40a20:a0:00:00
+0:40b22:46:1b:00 
+0:40b20:2:00:01
+
+;*******fax & fax (alt questions)
+fax:
+faxa:
+0:02b4:15e:00:00
+
+;Mille Miglia 2: Great 1000 Miles Rally (95/05/24) & (95/04/04)
+gtmr2a:
+gtmr2:
+0:103b1c:1a0:59:01
+0:103cfc:300:4d:2e
+
+;*******Gals Panic (set 3)
+galpanica:
+0:c825b6:64:30:31
+
+;*******caterpillar:
+caterplr:
+0:02:18:57:01
+0:1a:18:01:14
+
+;*******hyper pacman
+hyperpac:
+0:10315c:28:50:00
+
+;*******digger (cvs)
+diggerc:
+0:1cf8:2e:00:00
+0:1c01:1:a2:a2
+
+;*******vasara 2 (set 1 & 2)
+vasara2:
+vasara2a:
+0:5302:eb:01:0a
+
+;*******Twin Falcons
+twinfalc:
+0:e680:50:00:3b
+0:e600:08:00:00
+
+;********sun8.c (hard head & popper)
+hardhead:
+pop_hh:
+hardheadb:
+hardheadb2:
+0:ce80:18e:03:3d
+0:c051:3:00:00
+
+;*******fantasy land
+fantland:
+fantlanda:
+0:edc:28:50:0c
+
+;******************************************************************************************
+;* latest unofficial highscore_v0.84 additions below - by leezer/firebrand/geoman/others  *
+;******************************************************************************************
+
+;(empire city: 1931 (bootleg?)) and clones (by GeoMan)
+empcity:
+empcityi:
+empcityj:
+stfight:
+empcityu:
+stfighta:
+stfightgb:
+0:e012:55:00:45
+
+sabotenb:
+sabotenba:
+cactus:
+0:f6e00:6c:00:1e
+
+puchicar:
+puchicarj:
+0:401c7e:348:00:04
+
+;********megazone.c
+megazone:
+megazonei:
+megazonea:
+megazoneb:
+megazonec:
+0:2446:89:00:55
+0:3b08:4:00:00
+
+;(final blow (world)) (by GeoMan)
+finalb:
+finalbj:
+finalbu:
+0:101f22:4:00:00
+0:10104c:32:00:45
+
+;********cvs.c (gold bug)
+goldbug:
+0:3D09:1E:00:00
+
+;******tetris the grand master (japan 980710)
+;** this saves "today`s scores", the game saves the grand master scores using **
+;** nvram (i think !! :0)  **
+tgmj:
+0:80171198:35:06:64
+
+;******miss puzzle
+mspuzzle:
+0:100ff4:c:0b:f4
+0:100608:2f:4d:20
+
+;******monster maulers (Europe ver EAA)& kyukyoku sentai dadandarn (japan ver jaa)
+dadandrn:
+mmaulers:
+0:600701:99:02:e8
+
+headoni:
+;** does not save in game top score, only hiscore table saves **
+0:0e:f:00:00
+
+headon:
+headon1:
+;** does not save in game top score, only hiscore table saves **
+0:c780:1e:30:30
+
+headon2:
+0:c390:12:30:30
+
+headons:
+headonsa:
+headonmz:
+0:c78a:f:30:30
+
+headonb:
+0:ff06:4:00:00
+
+;******megatech: e-swat
+mt_eswat:
+0:ffff04:3:00:00
+
+;******megatech: columns
+mt_cols:
+0:fefa20:8e:00:00
+
+;******dyna gears
+;** top score updates as soon as 1st game starts **
+;** wait about 10 seconds after game starts before entering a credit, or save won`t work **
+dynagear:
+0:af:2c:80:50
+0:fd:1:04:04
+
+;******continental circus (world & us set 1)
+contcirc:
+contcircu:
+0:83064:257:00:41
+0:84582:4:00:e0
+0:826ef:1:52:52
+
+;******continental circus (us set 2)
+contcircua:
+0:8306a:257:00:41
+0:84582:4:00:e0
+0:826ef:1:52:52
+
+;*******1945k III
+1945kiii:
+1945kiiio:
+0:100a2d:63:03:88
+
+;********one + two
+onetwo:
+onetwoe:
+0:fcae:52:00:01
+
+seganinj:
+seganinju:
+nprinces:
+nprincesu:
+nprincesb:
+ninja:
+nprinceso:
+0:EF00:31:00:43
+
+;*******Renju Kizoku
+renju:
+0:f2aa:28:b8:01
+0:f2ea:2:70:17
+
+;*******Neratte Chu
+nratechu:
+0:e568:28:00:08
+
+;*******pirate treasure
+piratetr:
+0:2dc:4f:55:44
+
+;(leprechaun) and clones (by GeoMan) 
+;** let game display hiscore table a few times in attract mode before **
+;** starting a game **
+leprechn:
+potogold:
+leprechp:
+0:02ca:50:55:00
+
+;******super rider
+suprridr:
+0:80ca:3:00:00
+0:8a21:1:24:24
+0:8a01:1:24:24
+0:89e1:1:24:24
+0:89c1:1:24:24
+0:89a1:1:24:24
+0:8981:1:00:00
+
+;******driving force (pac-man conversion & clones)
+drivfrcp:
+drivfrcg:
+drivfrcb:
+drivfrct:
+0:3c05:49:20:20
+0:3c1f:1:31:31
+
+;******************************************************************************************
+;* latest unofficial highscore_v8.3 additions below - by leezer/firebrand/geoman/others   *
+;******************************************************************************************
+
+;*******spinner
+spinner:
+0:1c11:3:00:00
+0:1e40:f:00:00
+
+;********system18.c (shadow dancer)
+shdancer:
+shdancerj:
+shdancbl:
+shdancer1:
+0:ffec24:13a4:80:50
+
+;*******scooter shooter
+scotrsht:
+0:1ca0:46:01:1d
+0:199c:3:01:40
+
+;*******MTV Rock-N-Roll Trivia (Part 2)
+rocktrv2:
+0:4c2c:3c:44:0
+0:4c66:1:25:25
+0:43ed:6:00:40
+0:43f0:1:05:05
+
+highsplt:
+highsplta:
+0:60a9:3:00:00
+0:60a3:3:00:00
+0:609d:3:00:00
+0:60bb:3:00:00
+0:60b5:3:00:00
+0:60af:3:00:00
+0:60f1:3:00:00
+0:60ec:3:00:00
+0:60e7:3:00:00
+0:60cd:3:00:00
+0:60c7:3:00:00
+0:60c1:3:00:00
+
+highspltb:  ;******Space Fever High Splitter (alt Sound)
+0:60a9:3:00:00
+0:60f1:3:00:00
+0:60ec:3:00:00
+0:60e7:3:00:00
+0:60a3:3:00:00
+0:609d:3:00:00
+0:60bb:3:00:00
+0:60b5:3:00:00
+0:60af:3:00:00
+0:60cd:3:00:00
+0:60c7:3:00:00
+0:60c1:3:00:00
+
+gyrodinet:
+gyrodine:
+buzzard:
+0:f300:45:00:0b
+0:94e2:1:01:01
+0:94a2:1:01:01
+0:9462:1:03:03
+0:9422:1:06:06
+0:93e2:1:04:04
+0:93a2:1:00:00
+0:9362:1:00:00
+0:9322:1:00:00
+
+dkong3:
+dkong3j:
+dkong3b:
+0:6b00:aa:f3:76
+0:6c20:40:00:00
+0:6c16:04:00:00
+0:68f3:03:01:00
+
+changes:
+looper:
+changesa:
+0:899a:6:26:27
+0:89ba:6:00:00
+0:8a1a:6:26:27
+0:8a3a:6:00:00
+0:8a9a:6:26:27
+0:8aba:6:00:00
+
+;(violence fight (world)) (by GeoMan)
+viofight: 
+viofightu:
+viofightj:
+0:a02800:28:02:20
+
+;Teenage Mutant Ninja Turtles (US & clones)
+tmnt:
+tmntj:
+tmntua:
+tmht2p:
+tmnt2po:
+tmnt2pj:
+tmht:
+tmntu:
+tmht2pa:
+tmhta:
+tmhtb:
+0:63500:f3:03:41
+
+;(strikers 1945) (by tamphax)
+s1945:
+s1945j:
+s1945jn:
+s1945a:
+s1945k:
+s1945bl:
+0:fe2af8:78:2d:f8
+
+;********shienryu
+shienryu:
+0:60adc34:7ec:54:10
+0:60acbc4:4:00:e8
+
+;********Wiggie Waggie
+wiggie:
+0:ffe108:54:00:47
+
+;********timeplt.c
+timeplt:
+timepltc:
+spaceplt:
+timeplta:
+0:ab08:28:00:f1
+0:a98b:3:00:01
+
+mahoudai:
+sstrikera:
+sstriker:
+0:10029a:a4:00:20
+
+;********space launcher
+spacelnc:
+0:60bd:21:00:00
+
+spacefev:
+spacefevo:
+spacefevo2:
+0:60e7:3:00:00
+0:60f1:3:00:00
+0:60ec:3:00:00
+
+;*******Space Fever (black and white set 2)
+sfevrbwa:
+sfeverbw:
+0:609d:3:00:00
+0:60a3:3:00:00
+0:60a9:3:00:00
+0:60af:3:00:00
+0:60b5:3:00:00
+0:60bb:3:00:00
+0:60c1:3:00:00
+0:60c7:3:00:00
+0:60cd:3:00:00
+0:60e7:3:00:00
+0:60ec:3:00:00
+0:60f1:3:00:00
+
+;********galaga.c
+galaga:
+galagamk:
+galagamw:
+galagao:
+galagads:
+gallag:
+galagab2:
+galaga84:
+galagamf:
+0:8a20:2d:00:18
+0:83ed:6:00:24
+
+;********bulls eye darts
+bullsdrt:
+bullsdrtg:
+0:5c05:87:00:00
+0:5c5e:1:30:30
+0:5c06:1:00:00
+
+;********toaplan2.c
+battleg:
+battlegb: 
+0:10ca4c:ed:00:2a
+0:101241:1:45:45
+
+;********atetris.c
+atetris:
+atetrisb2:
+atetrisa:
+atetrisb:
+atetrisc2:
+atetrisc:
+atetrisb3:
+;0:979:90:30:52
+0:99d:3c:30:30
+0:9eb:1e:4b:52
+
+;********turbo.c (buck rodgers: planet of doom & clones)
+;** scores on the side of screen don`t display untill 1st game is over **
+;** also top side score may display 1 digit untill 1st game is over **
+buckrog:
+buckrogn:
+buckrogn2:
+0:c400:3e:00:00
+0:c549:10:ff:ff
+0:c54b:1:0f:0f
+
+zoom909:
+;** top score on game screen updated after 1st game **
+;** assuming you have made score display in dipswitch menu !!**
+0:c400:3e:00:00
+
+;******botanic
+botanic:
+botanicf:
+0:720a:46:18:10
+0:700a:1e:00:00
+0:7233:1:23:23
+
+;******bongo
+bongo:
+0:8300:11:0:15
+0:8301:1:05:05
+
+spang:
+sbbros:
+spangbl:
+spangj:
+0:fc01:9e:00:07
+0:e158:4:00:00
+
+;******triv four
+statriv4:
+0:482b:18:00:00
+
+;******pairs love:
+pairlove:
+0:f00748:63:00:2d
+
+outrun:
+outrunb:
+0:6046e:118:05:20
+
+outrunra:
+0:6046e:118:05:20
+0:604c8:1:4f:4f
+
+outrundxa:
+outrundx:
+outrundxj:
+0:6046e:118:01:20
+0:604c8:1:4f:4f
+
+;********mappy.c
+mappy:
+mappyj:
+0:1460:28:00:41
+0:1385:3:00:00
+0:07ed:6:00:20
+0:7e0:2:00:02
+
+;*******last striker / kyuukyoku no striker
+kyustrkr:
+0:f00d06:4f:41:4e
+
+;*******mobile suit gundam ex revue
+gundamex:
+0:2078a7:63:01:50
+
+;*******grand striker 2 (japan)
+gstrik2j:
+gstrik2e:
+0:ffaef3:48:76:28
+
+;*******goal `92
+goal92:
+0:109f57:99:28:01
+
+;*******dangerous dungeons
+ddungeon:
+ddungeone:
+0:915:9c:4b:30
+
+;*******space attack/head on
+sspacaho:
+0:e4cb:c:00:00
+0:878a:f:30:30
+
+;*******boxy boy (us) & souko ban deluxe (japan)
+;** do not use in game reset (f3) or save fails !! **
+;** saves hi-score and hiscore table - not step records **
+boxyboy:
+soukobdx:
+0:22d:3:00:00
+0:255:2c:09:00
+0:500f:1:03:03
+
+;*******cosmo
+cosmo:
+0:2038:3:00:00
+0:2e22:1:7c:7c
+0:2e42:1:82:82
+0:2e62:1:82:82
+0:2e82:1:82:82
+0:2ea2:1:7c:7c
+0:2f22:1:00:00
+0:2f42:1:00:00
+0:2f62:1:00:00
+0:2f82:1:00:00
+0:2fa2:1:00:00
+0:3022:1:00:00
+0:3042:1:00:00
+0:3062:1:00:00
+0:3082:1:00:00
+0:30a2:1:00:00
+0:3122:1:00:00
+0:3142:1:00:00
+0:3162:1:00:00
+0:3182:1:00:00
+0:31a2:1:00:00
+0:3222:1:00:00
+0:3242:1:00:00
+0:3262:1:00:00
+0:3282:1:00:00
+0:32a2:1:00:00
+0:3322:1:00:00
+0:3342:1:00:00
+0:3362:1:00:00
+0:3382:1:00:00
+0:33a2:1:00:00
+0:3422:1:00:00
+0:3442:1:00:00
+0:3462:1:00:00
+0:3482:1:00:00
+0:34a2:1:00:00
+
+;*******asterock
+asterock:
+asterockv:
+0:1c:35:00:00
+
+;*********(jackal (world)& top gunner (us)& top gunner (bootleg) & tokughu butai jackal (japan)
+jackal:
+topgunr:
+topgunbl:
+jackalj:
+jackalr:
+1:72f8:27:00:1d
+1:7340:3:00:00
+1:7341:1:02:02
+
+pacmania:
+pacmaniao:
+1:644:50:00:4d
+1:61c:4:00:00
+
+pacmaniaj:
+1:61c:4:00:00
+1:61e:1:50:50
+
+;******************************************************************************************
+;* latest unofficial highscore_v8.2 additions below - by leezer/firebrand/geoman/others   *
+;******************************************************************************************
+
+;*******lady frog
+ladyfrog:
+0:eb44:8f:dc:00
+0:ebd1:1:20:20
+
+;*******bakuretsu breaker
+bakubrkr:
+0:10c01a:63:00:4e
+
+;*******demoneye-x
+demoneye:
+0:128:b:00:00
+
+;********jumping cross
+jcross:
+0:f5ab:1e:00:49
+
+;********dorachan 
+dorachan:
+0:1815:5:00:00
+0:5d70:1:7c:7c
+0:5d71:1:8a:8a
+0:5d72:1:92:92
+0:5d73:1:a2:a2
+0:5d74:1:7c:7c
+0:5d78:1:7c:7c
+0:5d79:1:8a:8a
+0:5d7a:1:92:92
+0:5d7b:1:a2:a2
+0:5d7c:1:7c:7c
+0:5d80:1:7c:7c
+0:5d81:1:8a:8a
+0:5d82:1:92:92
+0:5d83:1:a2:a2
+0:5d84:1:7c:7c
+0:5d88:1:7c:7c
+0:5d89:1:8a:8a
+0:5d8a:1:92:92
+0:5d8b:1:a2:a2
+0:5d8c:1:7c:7c
+0:5d90:1:7c:7c
+0:5d91:1:8a:8a
+0:5d92:1:92:92
+0:5d93:1:a2:a2
+0:5d94:1:7c:7c
+
+;******porky
+porky:
+0:1c38:4a:00:20
+0:1c56:1:30:30
+
+;******big bucks
+bigbucks:
+0:4d7f:5f:48:00
+0:4ddc:1:20:20
+
+
+;******bang! (japan)
+bangj:
+0:fe5a50:f0:30:01
+
+;******prop cycle (rev.pr2 ver.a)
+;** bit dodgy this one - think it saves top ten hiscores tho......  ***
+propcycl:
+0:e04031:76:00:31
+0:e15bf9:226:00:0f
+
+;******super-x (ntc & mitchell)
+superx:
+superxm:
+0:d07c0:68:32:20
+
+;******speed arttack!
+speedatk:
+0:8a3c:4c:00:0f
+
+pacheart:
+0:43d1:2:4e:55
+0:4e88:3:00:00
+0:43ed:6:40:40
+
+;********pacland.c
+pacland:
+paclandj:
+paclandjo:
+paclandm:
+paclandjo2:
+0:2140:4a:00:e6
+0:205d:4:00:00
+
+paclandp:  ;*****not working/saving driver issue i think
+0:2100:6:00:00
+0:2110:4e:00:24
+0:2112:1:03:03
+
+;********jrpacman.c
+jrpacman:
+fastjr:
+jrpacad:
+jrhearts:
+jrvectr:
+jrpacmanf:
+0:4751:01:48:48
+0:476d:06:40:40
+0:4e88:03:00:00
+
+jrpacmbl:
+0:8e88:3:00:00
+0:876d:6:40:40
+0:8dce:1:03:03
+
+;*******street heat - cardinal amusements
+strtheat:
+0:6270:a7:01:20
+
+;*******gaia crusaders
+gaia:
+0:100030:9a:00:04
+
+;*******asura blade - sword of dynasty (japan)
+asurabld:
+0:4036ea:2:00:0a
+0:40370a:4:04:07
+0:40374a:4:00:50
+0:40378a:4:09:01
+0:40368b:1:10:10
+0:4036aa:4:00:00
+
+;*******twin eagle ii - the rescue mission
+twineag2:
+0:e208:3:40:0f
+0:15572:2f:40:0a
+
+;*******ultra x weapons / ultra keibitai
+ultrax:
+ultraxg:
+0:1ac8e:28:40:04
+0:e23c:3:40:0f
+
+;**btime by Ziller 
+vecbtime:
+0:0033:27:00:FF
+
+;*******centiped.c by Ziller 
+centidux:
+pacipede:
+vectiped:
+vectrped:
+killiped:
+0:000b:0f:10:01
+0:0023:0f:04:12
+
+;********dkong.c by Ziller 
+kong2600:
+0:6100:AA:94:76
+0:60B8:03:50:00
+0:7641:01:00:00
+0:7621:01:00:00
+0:7601:01:07:07
+0:75e1:01:06:06
+0:75c1:01:05:05
+0:75a1:01:00:00
+
+
+;********galaga.c by Ziller 
+galaga99:
+vgalaga:
+0:8a20:2d:00:18
+0:83ed:6:00:24
+
+;**galaxian: by Ziller 
+buglaxn:
+0:40a8:3:00:00
+
+;********milliped.c by Ziller 
+silliped:
+0:64:30:75:17
+0:24:1:a0:a0
+
+;********mrdo.c by Ziller 
+mrdigdo:
+0:e017:64:01:00
+
+;******zero point 2
+zeropnt2:
+0:fe901a:37:14:00
+0:fe904c:1:01:01
+
+8ballact: ;[Special thanks to Cananas for enhancing this entry]
+8ballact2:
+0:1d28:06:00:1b
+0:1d46:0a:00:00
+0:1d2e:06:00:1b
+0:1d50:0a:00:00
+0:1d34:06:00:1b
+0:1d5a:0a:00:00
+0:1d3a:06:00:1b
+0:1d64:0a:00:00
+0:1d40:06:00:1b
+0:1d6e:0a:00:00
+8bpm:
+0:1c6c:06:00:1b
+0:1c8a:0a:00:00
+0:1c72:06:00:1b
+0:1c94:0a:00:00
+0:1c78:06:00:1b
+0:1c9e:0a:00:00
+0:1c7e:06:00:1b
+0:1ca8:0a:00:00
+0:1c84:06:00:1b
+0:1cb2:0a:00:00
+
+;******special forces II(By Firebrand)
+spcfrcii:
+0:1a22:1:33:33
+0:1a27:5:30:30
+
+;******special forces(By Firebrand)
+spclforc:
+0:1a22:1:33:33
+0:1a27:5:30:30
+
+;******strike bowling(By Firebrand)
+;****no hiscore list per se but this will save the top 5 results permanantly
+;****if you like if not, you can disable this
+sbowling:
+0:fe61:f:00:00
+
+;******run and gun(By Firebrand)
+rungun:
+0:380c80:4b:4b:40
+
+;******locked and loaded(By Firebrand)
+lockload:
+0:102703:f6:20:1e 
+
+;******great guns(By Firebrand)
+greatgun:
+0:e00b:53:55:50 
+
+;******genix(By Firebrand)
+genix:
+0:10bd2c:64:4e:10
+
+;*******pit & run
+pitnrun:
+pitnruna:  ;******Pit & Run (set 2)
+0:8710:1e:00:01
+0:80aa:3:00:01
+0:8a21:1:01:01
+0:8a01:1:00:00
+0:89e1:1:00:00
+0:89c1:1:00:00
+0:89a1:1:00:00
+0:8981:1:27:27
+
+;******************************************************************************************
+;* latest unofficial highscore_v8.1 additions below - by leezer/firebrand/geoman/others   *
+;******************************************************************************************
+
+;*******evil stone
+;** the game hiscore is not working, but the hiscore table saves ok **
+evilston:
+0:a782:3c:01:2e
+
+;******change air blade(By Firebrand)
+cairblad:
+0:580030:b1:a0:01
+
+;*******stadium cross
+scross:
+scrossu:
+scrossa:
+0:701fb0:3f:53:03
+
+;*******r2d tank
+r2dtank:
+0:43:3:00:00
+0:48:1:a9:a9
+
+;*******grand tour
+grndtour:
+0:f182:29:41:00
+0:f1dd:4:00:00
+
+;*******enigma 2
+enigma2:
+enigma2a:
+enigma2b:
+0:20af:3:00:00
+0:20c1:3:24:24
+
+battlcry: ;[Special thanks to Cananas for making this entry work]
+0:4449:2a:48:00
+
+;******magical spot
+magspot:
+0:6007:3:00:00
+0:6008:1:20:20
+
+;********retofinv.c
+retofinv:
+retofinv2:
+retofinv1:
+0:9980:23:00:54
+0:990f:3:00:00
+
+;********(field day and clone)
+fieldday:
+undoukai: 
+0:c00d:536:48:11
+0:a190:1:03:03
+
+;*******ozon1
+ozon1:
+0:4047:3:00:00
+0:4300:4e:01:10
+
+;*******mustache boy
+mustache:
+0:f000:50:00:47
+
+;*******lethal enforcers II - gun fighters (ver eaa)
+le2:
+0:c03d98:3f:05:45
+
+;*******galaxy gunners
+galaxygn:
+0:01e9c:190:50:00
+0:0202a:1:0a:0a
+
+;********dragoon might (ver jaa)
+dragoonj:
+0:c01b00:9a:00:b0
+
+;********(steel gunner 2)
+sgunner2:
+sgunner2j:
+0:108e2b:1b7:00:02
+0:108c6b:9:00:00
+
+;*******zaviga(By Firebrand)
+zaviga:
+zavigaj:
+0:0da0:50:00:20
+0:1026:5:14:10 
+
+;*******tricky doc(By Firebrand)
+trckydoc:
+0:e05a:5a:2d:46 
+
+sdtennis: ;[Special thanks to Cananas for enhancing this entry]
+0:0200:3c:01:15
+0:0250:3c:3b:43
+0:002c:03:88:01 
+
+;*******rapid hero(Japan?)(By Firebrand)
+;wait to see top scores before you start a game
+raphero:
+0:1fe600:60:00:01 
+
+;*******progress(By Firebrand)(Hiscore does not seem to change during game)
+progress:
+0:8711:e:00:01 
+
+;*******prebillian(By Firebrand)(Hiscore display will not change. It is always 50,000. Please check)
+pbillian:
+0:f26b:23:00:45
+0:f222:3:00:00 
+
+;*******metal soldier issac II(By Firebrand)
+msisaac:
+0:e4a5:50:02:4d 
+
+;*******kung-fu taikun(By Firebrand)
+kungfut:
+kungfuta:
+0:c1d3:2c:00:1f 
+
+;*******kick start wheelie king(By Firebrand)
+kikstart:
+0:816f:3:00:00 
+
+;*******horizon(By Firebrand)
+horizon:
+0:e801:96:28:23
+0:e03c:2:28:06
+
+;*******straight flush
+;** gotta love those early videoram games !! **
+sflush:
+0:215:3:00:00
+0:4e3d:1:00:00
+0:4e5d:1:00:00
+0:4e7d:1:00:00
+0:4e9d:1:00:00
+0:4ebd:1:00:00
+0:4f3d:1:00:00
+0:4f5d:1:00:00
+0:4f7d:1:00:00
+0:4f9d:1:00:00
+0:4fbd:1:00:00
+0:503d:1:00:00
+0:505d:1:00:00
+0:507d:1:00:00
+0:509d:1:00:00
+0:50bd:1:00:00
+0:513d:1:3e:3e
+0:515d:1:45:45
+0:517d:1:49:49
+0:519d:1:51:51
+0:51bd:1:3e:3e
+0:523d:1:3e:3e
+0:525d:1:45:45
+0:527d:1:49:49
+0:529d:1:51:51
+0:52bd:1:3e:3e
+0:533d:1:00:00
+0:535d:1:00:00
+0:537d:1:00:00
+0:539d:1:00:00
+0:53bd:1:00:00
+
+;*******sky army
+skyarmy:
+0:8131:ad:00:8a
+
+;*******sd gundam neo battling (japan)
+neobattl:
+0:2006a4:78:00:0a
+
+;*******rock climber
+rockclim:
+0:80d9:15:03:00
+0:80eb:1:03:03
+
+;*******puckman pockimon
+puckpkmn:
+puckpkmna:
+puckpkmnb:
+0:ff0020:30:38:36
+
+;*******nitroball (us)
+nitrobal:
+gunball:
+nitrobala:
+0:ff9deb:14b:54:00
+0:ff803a:4:00:00
+0:ff803b:1:10:10
+
+;*******metal clash (japan)
+metlclsh:
+0:802f:8c:47:40
+0:800a:3:30:05
+
+;*******mach breakers (japan)
+machbrkr:
+0:23f532:f6:03:30
+
+;*******boardwalk casino
+;** only saves the top score of each card game **
+bwcasino:
+0:4c3c:d2:00:00
+0:4cce:1:43:43
+
+;*******twin bee yahhoo! (ver jaa)
+tbyahhoo:
+0:c0fb42:82:00:12
+0:c0fb43:1:57:57
+
+;*******the deep (japan)
+thedeep:
+rundeep:
+0:c256:3c:04:04
+
+;*******fire battle
+firebatl:
+0:8000:21:54:00
+0:801f:1:70:70
+
+;*******head panic(Korea?)(By Firebrand)
+hedpanic:
+hedpanicf:
+hedpanico:
+0:10a840:28:00:40
+
+;*******champion pro wrestling(By Firebrand)
+chwrestl:
+0:c009:3:00:00
+0:c00c:3:00:00 
+
+;*******vasara
+vasara:
+0:2a32:c5:01:1e
+
+;*******salamader 2 (jaa)
+salmndr2:
+0:c02033:136:0:14
+
+;*******sexy parodius (ver jaa)
+sexyparo:
+sexyparoa:
+0:c10752:4:00:00
+0:c1075e:78:00:06
+0:c10754:1:73:73
+
+;*******eggor
+eggor:
+0:4cf7:3c:4c:00
+0:4d31:1:52:52
+0:43ed:6:00:40
+
+;*******dark tower
+darktowr:
+0:a82:9c:4b:30
+
+;*******chack`n pop
+chaknpop:
+0:8449:1f:04:00
+0:8466:1:14:14
+
+;*******battle wings
+bwing:
+0:d00:f0:34:20
+0:0d:4:00:00
+
+;*******cuebrick
+cuebrick:
+cuebrickj:
+0:60368:50:00:4f
+
+;********************************************************************************
+;* latest unofficial highscore_v7.97 additions below - by leezer/geoman/others  *
+;********************************************************************************
+
+;*******arcade classics (prototype)
+;** this entry saves all but the top 4 scores, nvram does the rest **
+arcadecl:
+0:3eee41:32:00:11
+0:3eedf6:32:00:10
+
+ghunter:
+0:1462:bd:50:00
+0:1519:1:2a:2a
+
+;*******dead angle
+deadang:
+0:1442:bd:50:00
+0:14f9:1:2a:2a
+
+ghunters:
+0:1482:bd:50:00
+0:1539:1:2a:2a
+
+leadang:
+0:1542:bd:50:00
+0:15f9:1:2a:2a
+
+;*******gokujyou parodius (ver jad)
+gokuparo:
+0:c0d736:4:00:00
+0:c0d742:78:00:09
+0:c0d738:1:73:73
+
+;*******mystic warriors (world ver eaa)
+mystwarr:
+mystwarrj:
+mystwarru:
+mystwarra:
+mystwarraa:
+0:200400:4e:48:01
+0:200170:4:00:00
+0:200171:1:10:10
+
+;*******guardians/denjin makai II(By Firebrand)
+grdians:
+0:201582:4a:c3:01
+
+;*******dragon gun(us)(By Firebrand)
+dragngun:
+dragngunj:
+0:011f384:13d:20:1b
+
+;*******cave.c (esp.ra.de) (International Ver 1998 4/22 and clones)
+esprade:
+espradejo:
+espradej:
+0:1023b0:50:00:8c
+0:1022ec:4:00:00
+
+;*******tecmo bowl (world? & japan)	
+tbowl:
+tbowlj:
+tbowlp:
+0:8015:b4:41:01
+
+;*******thunderjaws
+thunderj:
+thunderja:
+0:3ffd9c:64:00:95
+
+;*******dragon master
+drgnmst:
+0:ff84f0:4:00:00
+0:ff8450:6c:00:01
+
+;*******las vegas girl (girl`94)
+lvgirl94:
+0:c17cd:77:53:00
+0:c1840:1:07:07
+0:c23da:6:00:00
+
+boggy84b:
+0:c400:45:00:11
+0:c044:6:10:10
+0:c04b:3:00:00
+
+boggy84:
+0:c400:45:00:11
+0:c044:6:10:10
+0:c04b:3:00:00
+
+;*******off the wall (2/3 player upright))
+offtwall:
+offtwallc:
+0:3fee2e:37:00:49
+
+;********bublbobl.c
+;**** now saves all hiscore data and special item counters ****
+bublbobl:
+bub68705:
+bublboblr:
+bublboblr1:
+boblbobl:
+bublbobl1:
+boblbobl2:
+sboblbobl:
+bbredux:
+bublboblb:
+bublcave10:
+bublcave11:
+sboblboblc:
+0:e654:23:00:48
+0:e67b:3:1f:13
+0:e64c:3:00:00
+0:e5df:1:00:00
+0:e5e0:1:00:00
+0:e5e4:1:00:00
+0:e5e6:1:00:00
+0:e5e1:1:00:00
+0:e5e2:1:00:00
+0:e5e3:1:00:00
+0:e5e7:1:00:00
+0:e5e8:1:00:00
+0:e5e9:1:00:00
+0:e5ea:1:00:00
+0:e5eb:1:00:00
+0:e5f6:1:00:00
+0:e5f7:1:00:00
+0:e5ee:1:00:00
+0:e5ef:1:00:00
+0:e5f0:1:00:00
+0:e5ec:1:00:00
+0:e5ed:1:00:00
+0:e5f3:1:00:00
+0:e5f4:1:00:00
+0:e5d9:1:00:00
+0:e5da:1:00:00
+0:f457:1:00:00
+0:f458:1:00:00
+0:e601:1:00:00
+0:e602:1:00:00
+0:e600:1:00:00
+0:e5ff:1:00:00
+0:e5fd:1:00:00
+0:e5fc:1:00:00
+0:e5fb:1:00:00
+0:e5fa:1:00:00
+0:e5f9:1:00:00
+0:e5f8:1:00:00
+0:e5fe:1:00:00
+0:e604:1:00:00
+0:e605:1:00:00
+0:e606:1:00:00
+0:e607:1:00:00
+0:e609:1:00:00
+0:e60a:1:00:00
+0:e611:1:00:00
+0:e60b:2:00:00
+
+sboblbob:  
+sboblboa:  ;******Super Bobble Bobble (set 1)
+sboblbobla:
+sboblboblb:
+sboblbobld:
+0:e654:23:00:48
+0:e67b:3:1f:13
+0:e64c:3:00:00
+0:cfc6:1:60:60
+0:d006:1:60:60
+0:d046:1:60:60
+0:d086:1:7e:7e
+0:d0c6:1:7b:7b
+0:d106:1:7b:7b
+0:d146:1:7b:7b
+0:d186:1:7b:7b
+0:e5df:1:00:00
+0:e5e0:1:00:00
+0:e5e4:1:00:00
+0:e5e6:1:00:00
+0:e5e1:1:00:00
+0:e5e2:1:00:00
+0:e5e3:1:00:00
+0:e5e7:1:00:00
+0:e5e8:1:00:00
+0:e5e9:1:00:00
+0:e5ea:1:00:00
+0:e5eb:1:00:00
+0:e5f6:1:00:00
+0:e5f7:1:00:00
+0:e5ee:1:00:00
+0:e5ef:1:00:00
+0:e5f0:1:00:00
+0:e5ec:1:00:00
+0:e5ed:1:00:00
+0:e5f3:1:00:00
+0:e5f4:1:00:00
+0:e5d9:1:00:00
+0:e5da:1:00:00
+0:f457:1:00:00
+0:f458:1:00:00
+0:e601:1:00:00
+0:e602:1:00:00
+0:e600:1:00:00
+0:e5ff:1:00:00
+0:e5fd:1:00:00
+0:e5fc:1:00:00
+0:e5fb:1:00:00
+0:e5fa:1:00:00
+0:e5f9:1:00:00
+0:e5f8:1:00:00
+0:e5fe:1:00:00
+0:e604:1:00:00
+0:e605:1:00:00
+0:e606:1:00:00
+0:e607:1:00:00
+0:e609:1:00:00
+0:e60a:1:00:00
+0:e611:1:00:00
+0:e60b:2:00:00
+
+boblcave:
+bublcave:
+0:e654:23:00:4e
+0:e67b:3:1f:13
+0:e64c:3:00:00
+0:e5df:1:00:00
+0:e5e0:1:00:00
+0:e5e4:1:00:00
+0:e5e6:1:00:00
+0:e5e1:1:00:00
+0:e5e2:1:00:00
+0:e5e3:1:00:00
+0:e5e7:1:00:00
+0:e5e8:1:00:00
+0:e5e9:1:00:00
+0:e5ea:1:00:00
+0:e5eb:1:00:00
+0:e5f6:1:00:00
+0:e5f7:1:00:00
+0:e5ee:1:00:00
+0:e5ef:1:00:00
+0:e5f0:1:00:00
+0:e5ec:1:00:00
+0:e5ed:1:00:00
+0:e5f3:1:00:00
+0:e5f4:1:00:00
+0:e5d9:1:00:00
+0:e5da:1:00:00
+0:f457:1:00:00
+0:f458:1:00:00
+0:e601:1:00:00
+0:e602:1:00:00
+0:e600:1:00:00
+0:e5ff:1:00:00
+0:e5fd:1:00:00
+0:e5fc:1:00:00
+0:e5fb:1:00:00
+0:e5fa:1:00:00
+0:e5f9:1:00:00
+0:e5f8:1:00:00
+0:e5fe:1:00:00
+0:e604:1:00:00
+0:e605:1:00:00
+0:e606:1:00:00
+0:e607:1:00:00
+0:e609:1:00:00
+0:e60a:1:00:00
+0:e611:1:00:00
+0:e60b:2:00:00
+
+;*******(oli-boo-chi)
+;** game updates saved hiscore as soon as you insert a coin **
+olibochu:
+0:f84c:5:00:00
+0:f84e:1:05:05
+0:81bd:1:60:60
+0:81dd:1:60:60
+0:81fd:1:05:05
+0:821d:1:00:00
+0:823d:1:00:00
+0:825d:1:00:00
+0:814f:1:18:18
+
+;*******(birdie king 2)(By Firebrand)
+bking2:
+0:8166:9:0:0
+0:8187:1:0:0
+
+;*******(world rally 2: twin racing)(By Firebrand)
+wrally2:
+0:fec766:288:5a:ff
+
+;*******(ghost pilots)(By Firebrand)
+gpilots:
+0:10e001:3:00:00
+0:10e005:4b:00:10
+
+;*******(grand striker)(By Firebrand)
+gstriker:
+gstrikera:
+0:ffe357:43:0f:01
+
+gstrikerj:
+0:ffe349:43:0f:01
+
+;*******(mad shark)
+madshark:
+0:201d20:4:00:00
+0:205dd2:c4:00:00
+0:201d21:1:0a:0a
+
+;*******(mad donna (set 1))
+maddonna:
+0:835fc:4:00:30
+
+;*******(raiga - strato fighter)(US and Japan)(By Firebrand)
+stratof:
+raiga:
+0:060082:8c:00:20
+
+;*******(halley's comet)(By Firebrand)
+halleys:
+halleycj:
+halleysc:
+0:fc3c:23:02:54
+0:fc21:3:02:00
+
+halley87:
+0:fc5a:23:02:54
+0:fc3f:3:02:00
+
+;*******(gigas mark II)(bootleg)(By Firebrand)
+gigasm2b:
+0:c0a0:4d:00:20
+
+gigasb:
+gigas:  ;******Gigas
+0:cb10:4d:80:20
+
+oigas:
+0:cb10:4d:90:59
+
+;*******(crowns golf (set 1))
+crgolf:
+0:4001:10c:04:00
+0:411a:1:0a:0a
+
+;*******(fantasy `95)
+fantsy95:
+0:c825b6:63:30:20
+
+;*******dorodon (set 1)
+dorodon:
+dorodon2:
+0:6073:1b:01:00
+0:d381:46:0f:17
+
+;*******ben bero beh (japan)
+benberob:
+0:fa4d:3:00:96
+
+;*******pistol daimyo no bouken(Japan)(By Firebrand)
+pistoldm:
+0:01f7:23:05:33
+0:015c:4:05:00
+
+;********the game paradise - master of shooting
+gametngk:
+0:fee0021e:4:40:00
+0:fc000450:15cd:47:20
+0:fee16000:44d:47:00
+0:fee16448:1:01:01
+
+;********macross II(By Firebrand)(redited to include each stage's hiscore 
+;and all ranks)
+macross2:
+macross2g:
+0:1ffa00:80:00:50
+0:1ffb00:80:00:50
+0:1ffc00:80:00:50
+0:1fc400:200:00:73
+0:1fc600:200:00:73
+0:1fc800:200:00:73
+0:1fca00:200:00:73
+0:1fcc00:200:00:73
+0:1fce00:200:00:73
+0:1fd000:200:00:73
+0:1fd200:200:00:73
+0:1fd400:200:00:73
+0:1fd600:200:01:63
+
+;*******thunder zone(world)(By Firebrand)
+thndzone:
+thndzonea:
+0:3f8040:1a:10:10
+
+thndzonej:
+0:3f8038:1a:10:10
+
+thndzone4:
+0:3f803c:1e:19:01
+
+dassault4:
+0:3f803c:1e:19:01
+
+dassault:
+0:3f803c:1e:19:10
+
+;*******mayhem 2002(By Firebrand)
+; - Only works if you delete the nvram after you turn off the game. Making 
+;the nvram read-only will not work.
+mayhem:
+0:e081:ba:10:45
+
+;*******super triv II(By Firebrand)
+; - Only saves "Experts Only" scores, can save other slots but the games are 
+;different every time
+;, - unless you choose the same three over and over again so only "Experts 
+;Only" game stays the same.
+supertr2:
+0:4891:20:00:00
+
+;*******golly! ghost!(By Firebrand)(unable to test properly due to lack of 
+;sight movement on screen)
+gollygho:
+0:10312E:143:02:00
+
+wizdfire:
+wizdfireu:
+darkseal2:
+0:fdc034:28:0b:00
+0:fdc059:1:01:01
+
+;********mutant fighter (world rev 4 em-5)
+mutantf:
+deathbrd:
+mutantf3:
+mutantf4:
+mutantf2:
+0:1000fc:32:01:00
+0:10012c:1:01:01
+
+;********perestroika girls (japan)
+perestro:
+perestrof:
+0:f4c0:28:00:03
+0:f8f1:4:00:00
+
+;********the cliffhanger - edward randy (world revision 2))
+edrandy:
+edrandyj:
+edrandy1:
+edrandy2:
+0:194080:80:4d:02
+
+;********btime.c
+bnj:
+brubber:
+bnjm:
+0:000a:3:12:01
+0:500:26c:01:00
+0:640:1:4d:4d
+
+tubep:
+0:a0b6:240:a8:4d
+0:a092:3:a8:00
+
+tubepb:
+0:a095:240:a8:4d
+0:a080:3:a8:00
+
+;********neogeo.c (blues journey)
+bjourney:
+0:103381:49:05:05
+
+;*******(mega twins [updated])
+mtwins:
+chikij: 
+0:ff12c8:190:00:00
+0:ff9168:28:02:5b
+0:ffe006:04:00:00
+
+;********************************************************************************
+;* latest unofficial highscore_v7.96 additions below - by leezer/geoman/others  *
+;********************************************************************************
+
+tmnt2:
+tmnt2a:
+tmht22pe:
+tmnt22pu:
+0:107600:14:03:01
+0:1076c8:27:47:45
+
+;*******(p-47 aces)
+p47aces:
+0:fee1b04c:78:10:03
+
+;*******(mouser/mouser (cosmos))
+mouser:
+mouserc:
+0:6107:a1:00:00
+0:60b8:3:00:00
+0:61a6:1:23:23
+0:9241:1:00:00
+0:9221:1:00:00
+0:9201:1:07:07
+0:91e1:1:08:08
+0:91c1:1:00:00
+0:91a1:1:00:00
+
+;*******(birdy try (japan))
+birdtry:
+0:ff8530:31a:01:40
+
+;*******(f1 exhaust note)
+;** needs testing - can anyone verify this game saves hiscores ?? **
+f1en:
+f1enu:
+f1enj:
+0:20f20e:38:42:02
+
+;mars matrix (usa/japan)(by tamphax)
+mmatrix:
+mmatrixj:
+mmatrixd:
+0:ff0104:140:43:00
+0:ff4988:6:00:90
+
+;zombie raid (by tamphax)
+zombraid:
+zombraidp:
+zombraidpj:
+0:20cabc:50:4f:00
+
+;street fighter 2 (US 910318)(clone)(by tamphax)
+sf2ud:
+0:ffd28a:30:00:20
+0:ffd302:04:00:00
+
+;willow (japan, english)(clone)(by tamphax)
+willowo:
+willowuo:
+0:ffefc6:50:00:20
+0:fff03e:04:00:00
+
+willow:
+willowj:
+willowu: 
+0:ffefc6:50:00:20
+0:fff03e:04:00:00
+
+
+;spiderman (us) and clones (by GeoMan)
+spidey:
+spideyj:
+0:208c00:80:a0:00
+
+;perfect billiards (by GeoMan)
+pbillrd:
+pbillrds:
+pbillrdsa:
+0:c940:A0:00:40
+
+;******(enforce (japan))
+enforce:
+enforcej:
+enforceja:
+0:1026fc:4:00:a0
+
+;maniac square (unprotected)(by tamphax)
+maniacsq:
+maniacsqa:
+0:fe982c:48:50:00
+
+;maniac square (prototype)(by tamphax)
+maniacsp:
+0:ff713e:64:50:00
+
+;liberation (by tamphax)
+liberate:
+dualaslt:
+liberateb:
+0:41:3:05:00
+0:6304:6e:20:60
+
+;SF-X (by tamphax)
+sfx:
+0:40a8:3:00:02
+0:4540:1e:00:15
+
+;*******(gumbo)
+;** this hiscore seems broken, think its a driver problem **
+gumbo:
+mspuzzleg:
+0:80000:30:4b:50
+0:815d2:12:0b:0a
+
+;*******(F-1 grand prix part II)
+f1gp2:
+0:ff91c2:2ee:14:50
+0:ffa617:3f:59:49
+
+;gunbarich (by tamphax)
+gnbarich:
+0:6076864:a5:00:01
+
+;strikers 1945 III (by tamphax)
+s1945iii:
+0:6083c84:c4:00:00
+0:6083d80:46:00:02
+
+;dragon blaze (by tamphax)
+dragnblz:
+0:60824B4:dd:00:00
+0:60825d4:4d:00:03
+
+;*******(bang!)
+bang:
+0:fe5a4c:ee:41:01
+
+;*******(alligator hunt (unprotected))   
+aligatorun:
+0:fe51da:2:42:68
+0:feaf02:98:42:2e
+
+;*******(boomer rang`r / genesis)
+;** you must let this game display the hiscore table before starting game and **
+;** this game only saves properly if you exit the game when the hiscore is scrolling **
+;** up the screen during attract mode, you have to be quick, you only get about 4-5 seconds **
+;** to do this...**
+boomrang:
+boomrana:
+0:10:3:07:00
+0:62a2:3f:07:89
+
+;*******(penguin brothers (japan))
+penbros:
+0:200050:63:00:4a
+
+;Dimahoo/Great Mahou Daisakusen (by tamphax)
+dimahoo:
+gmahou:
+dimahoou:
+dimahoud:
+0:928586:3C:00:40
+
+;(dragonball z 2 super battle) (by GeoMan)
+dbz2:
+0:48772a:2:00:02
+0:48772c:2:00:00
+
+;******(gratia - second earth)
+gratia:
+gratiaa:
+0:fee1bc2c:a0:c8:43
+
+;******(desert war)
+desertwr:
+0:fee1b028:eb:94:24
+
+;******(tetris plus)
+tetrisp:
+0:fee184a0:135:10:1e
+0:fee00010:31e:5a:ea
+
+;******(the history of martial arts)
+histryma:
+0:e02be0:28:41:10
+
+;******(puzz loop (europe))
+puzzloope:
+puzzloop:
+0:60985ac:41:00:31
+0:60986d4:41:00:30
+
+puzzloopa:
+0:609c4b8:41:00:31
+0:609c5e0:41:00:30
+
+puzzloopj:
+0:609d1a8:41:00:30
+0:609d080:41:00:31
+
+puzzloopk:
+puzzloopu:
+0:609c700:41:00:30
+0:609c5d8:41:00:31
+
+;********(speed spin)
+speedspn:
+0:b04c:61:4a:20
+
+;********(sky raider)
+skyraid:
+0:a:2:00:00
+
+;********(sengeki striker)
+;** the nvram in this game is about as reliable as the english cricket team, hence **
+;** the top score is sometimes wrong.... but nevermine eh...?? **
+;** the todays top ten hi table saves fine though... **
+sengekis:
+sengekisj:
+0:60b1de8:78:53:00
+0:60b1e47:1:01:01
+
+;********(solvalou)
+solvalou:
+0:10660f:119:00:07
+
+;********(s.s.mission)
+ssmissin:
+0:b9100:c0:00:6f
+
+;********(megadon)
+;** only saves top score ???? don`t know why ???? anyone fix this ??  **
+megadon:
+0:7a01:48:00:00
+0:7a6e:2:01:00
+0:7862:1:f4:f4
+
+;********(legion(ver 2.03 & 1.05))
+legion:
+0:62e8e:27:00:29
+0:62fde:4:00:00
+legiono:
+legionjb:
+legionj:
+0:62e8c:27:00:29
+0:62fdc:4:00:00
+
+;********(legend)
+legend:
+legendb:
+0:e70c:5d:00:40
+
+;********(kid no hore hore daisakusen)
+horekid:
+horekidb:
+boobhack:
+0:4025a:28:00:01
+
+;********(ipm invader)
+ipminvad:
+0:c0:a:00:00
+
+;********(golden fire II)
+gfire2:
+0:1003d:45:4f:4a
+
+;********(best bout boxing)
+bbbxing:
+0:fee0f45c:d7:a0:53
+
+;********(alpha fighter / head on)
+alphaho:
+0:878a:f:30:30
+0:e4cb:c:00:00
+
+;********(samurai aces (world))
+samuraia:
+0:fe7d80:9e:00:04
+
+;********(flower)
+flower:
+flowersj:
+0:d060:37:00:20
+0:c00f:3:00:00
+0:c010:1:30:30
+
+;********(fancy world - earth of crisis)
+fncywld:
+0:ff8311:ae:05:56
+
+;********(bouncing balls)
+bballs:
+bballsa:
+0:fc688:31:90:90
+0:fc687:1:00:00
+
+;(tengai) (by tamphax)
+tengai:
+tengaij:
+0:fe4cb0:48:2d:98
+
+;(Blaze On) (by tamphax)
+blazeon:
+0:304fb0:77:00:0d
+0:30020c:8:00:00
+
+;********(blandia)
+blandia:
+0:301094:62:09:17
+
+;********(aquarium (japan))
+aquarium:
+aquariumj:
+0:ff904c:28:49:e8
+
+;********(masked riders club battle race)
+kamenrid:
+0:202e93:9f:0a:10
+
+;********(n.y. captor)
+;** hiscore is broken in this game, when h/score is beaten you cannot put your name in **
+;** the scores save ok though...  **
+nycaptor:
+0:e1da:28:00:4e
+0:e188:3:00:00
+
+;********(sky skipper)
+skyskipr:
+0:81f2:3:01:00
+0:8610:1e:01:16
+
+;********(diver boy)
+diverboy:
+0:44715:b1:31:e9
+
+;********(nostradamus)
+nost:
+0:100350:29:59:00
+0:100019:3:01:00
+
+;********(beam invader)
+beaminv:
+beaminva:
+pacominv:
+0:1833:3:00:00
+
+;Armored Warriors(Europe/USA) (by tamphax)
+armwar:
+armwaru:
+armwara:
+armwarar1:
+armwar1d:
+armwarr1:
+armwaru1:
+pgearr1:
+pgear:
+0:ff27d6:256:00:04 
+
+;(cassette: tornado) (by GeoMan)
+ctornado:
+0:25:3:0:0
+
+;(cassette: terranean) (by GeoMan)
+cterrani:
+0:44:2:0:50
+0:46:1:0:0
+
+;(cassette: super astro fighter) (by GeoMan)
+csuperas:
+0:480:1c:0:ff
+0:98:2:0:0
+
+;(cassette: scrum try (set 1)) and clones (by GeoMan)
+cscrtry:
+0:400:21:01:15
+0:a:3:10:01
+cscrtry2:
+0:400:24:0:2b
+0:a:3:0:0
+0:ca41:1:1:1
+0:ca21:1:2b:2b
+0:ca01:1:2b:2b
+0:c9e1:1:2b:2b
+0:ca61:1:1:1
+0:c9c1:1:2b:2b
+
+;********************************************************************************
+;* latest unofficial highscore_v7.95 additions below - by leezer/geoman/others  *
+;********************************************************************************
+
+;******(up`n down (not encrypted))
+upndownu:
+0:c93f:3f:01:00
+0:c97b:1:01:01
+
+upndown:
+0:c93f:3f:01:00
+
+wilytowr:
+atomboy:
+atomboya:
+0:dd00:4:00:05
+0:dd04:ac:0:0
+0:e78d:6:ff:ff
+
+;(jump kids) (by GeoMan)
+jumpkids:
+0:123c10:a0:50:50
+0:123c01:3:0:0
+
+;(inferno (s2650)) (by GeoMan)
+minferno:
+0:1c3a:5:10:10
+
+;(high voltage) (by GeoMan) - For the hiscore to display correctly in the opening screen always quit the game when opening screen is displayed!
+hvoltage:
+0:40d20:1e0:4c:00
+0:40020:3:01:00
+0:201615:1:20:20
+0:201695:1:01:01
+0:201715:1:0:0
+0:201795:1:0:0
+0:201815:1:0:0
+0:201895:1:0:0
+0:201915:1:0:0
+
+;(gulf war ii) (by GeoMan)
+gulfwar2:
+gulfwar2a:
+0:315a6:16a:00:01
+0:315a2:4:0:0
+
+;******F-1 Grand Prix (by GeoMan, GP records by GreatStone)
+f1gp:
+0:ff917a:2f0:14:00
+0:ffa5cb:3f:59:49
+
+;(equites) and clones (by GeoMan)
+equites:
+equitess:
+0:40020:4:0:0
+0:40a30:a0:00:09
+
+;(clay shoot) (by GeoMan)
+clayshoo:
+0:2140:8:be:00
+
+;(dingo) (by GeoMan)
+dingo:
+0:4028:31:0:0
+
+;(roller jammer) (by GeoMan)
+rjammer:
+0:a4fa:1e:a8:55
+
+;(rip cord) (by GeoMan)
+ripcord:
+0:36:2:0:0
+
+;(next space, the) (by GeoMan)
+tnexspce:
+0:70016:4:0:0
+0:72b40:50:0:0
+0:a0f56:10:30:4e
+
+;(net wars) (by GeoMan)
+netwars:
+0:5890:6:00:00
+0:8040:1:24:24
+0:8060:1:0:0
+0:8080:1:0:0
+0:80a0:1:0:0
+0:80c0:1:0:0
+0:80e0:1:1:1
+0:8100:1:24:24
+0:8110:1:24:24
+
+;(lethal crash race (set 1)) and clones (by GeoMan)
+crshrace:
+crshrace2:
+0:fe21b6:80:41:00
+
+;(koukouyakyuh, the) (by GeoMan)
+kouyakyu:
+0:40a01:70:0:0
+0:40010:4:0:0
+0:8070d:1:20:20
+0:8078d:1:20:20
+0:8080d:1:2:2
+0:8088d:1:0:0
+0:8090d:1:0:0
+0:8098d:1:0:0
+0:80a0d:1:0:0
+
+;********decocass.c (cassette: peter peppers ice cream factory)
+cppicf:
+cppicf2:
+0:d940:1e:05:00
+0:d800:1e:4d:00
+0:3:3:00:05
+0:94:1:13:13
+
+;(cassette: rootin' tootin' (aka la.pa.pa)) and clones (by GeoMan)
+clapapa:
+clapapa2:
+0:1:2:00:45
+0:3:1:0:0
+
+;(cassette: pro soccer) (by GeoMan)
+cprosocc:
+cpsoccer:
+0:56a:23:00:00
+0:591:3:0:0
+
+;(cassette: night star (set 1)) and clones (by GeoMan)
+cnightst:
+cnightst2:
+0:d:2:00:03
+0:7800:40:03:00
+0:7940:40:6b:00
+
+;(cassette: mission-x) (by GeoMan)
+cmissnx:
+0:23:3:0:0
+
+;(toffy) (by GeoMan)
+toffy:
+0:913:a0:20:ff
+
+;(battle cross) (by GeoMan)
+battlex:
+0:a036:3:0:0
+0:a266:23:0:0
+
+;(bakutotsu kijuutei) (by GeoMan)
+bakutotu:
+0:1e00:60:42:50
+
+;*********(tube-it)
+tubeit:
+0:8d0d:4c:4b:00
+0:8d57:1:10:10
+
+;********************************************************************************
+;* latest unofficial highscore_v7.94 additions below - by leezer/geoman/others  *
+;********************************************************************************
+
+;(storm blade (us)) (by GeoMan)
+stmblade:
+stmbladej:
+0:28d3:80:15:00
+
+;(splendor blast) (by GeoMan)
+splndrbt:
+0:40840:168:53:01
+0:40020:3:01:00
+
+;(space king 2) (by GeoMan)
+spcking2:
+0:1cf4:2:0:0
+
+;(beast busters (world ?)) (by GeoMan)
+bbusters:
+bbustersua:
+bbustersu:
+0:8a578:2:00:02
+0:8a57a:be:30:00
+
+;(birdie king) (by GeoMan)
+bking:
+0:8161:9:0:0
+0:8175:1:0:0
+
+;********(red robin)
+redrobin:
+0:c743:3b:1b:00
+0:c6e6:3:01:00
+
+;********(monte carlo)
+montecar:
+0:b6:1:00:00
+
+;********(macross plus)
+macrossp:
+0:f16ddc:5e:00:14
+
+;(cassette: lock'n'chase) (by GeoMan)
+clocknch:
+0:a:3:0:0
+0:b800:f:0:0
+0:b810:11:ff:0
+
+;(cassette: fighting ice hockey) (by GeoMan)
+cfghtice:
+0:c2:3:02:0
+0:4b09:50:20:00
+
+;(cassette: disco no 1) and clones (by GeoMan)
+cdiscon1:
+csweetht:
+0:8:3:0:0
+0:400:21:0:0
+
+;(cassette: bump n jump) and clones (by GeoMan)
+cburnrub:
+cbnj:
+cburnrub2:
+0:9:3:12:01
+0:7800:f:01:82
+0:9800:f:4d:4d
+
+;********(super shanghai dragon`s eye (world,bootleg))
+sshanghab:
+sshangha:
+0:fec478:13f:00:1c
+
+;(american horseshoes (us)) (by GeoMan)
+horshoes:
+0:8e1c:2:0:0
+0:8f37:1:0:0
+0:8ff0:1:0:0
+0:8bd0:1:4c:4c
+
+;(exvania (japan)) (by GeoMan)
+exvania:
+exvaniaj:
+0:214ee8:28:50:02
+
+;(gunbuster (japan)) (by GeoMan)
+gunbustr:
+gunbustru:
+gunbustrj:
+0:2032a0:2:00:21
+0:2032a2:9e:13:00
+
+;(yamato (set 1)) and clones (by GeoMan)
+yamato:
+yamato2:
+0:6100:50:00:ff
+0:6038:3:00:00
+
+;(us aaf mustang (japan)) and clones (by GeoMan)
+mustang:
+mustangb:
+mustangs:
+mustangb2:
+0:f9090:4:00:10
+
+;(sotsugyo shousho) (by GeoMan)
+sotsugyo:
+0:14269c:10:00:32
+0:1426ac:50:04:00
+
+;(sokonuke taisen game (japan)) (by GeoMan)
+sokonuke:
+0:208004:10:00:46
+0:208014:40:00:00
+
+;(sea fighter poseidon) (by GeoMan)
+sfposeid:
+0:8188:2:00:50
+0:818a:1:00:00
+
+;(s.p.y. - special project y (us)) (by GeoMan)
+spy:
+spyu:
+0:9a0:50:11:00
+0:836:4:00:00
+
+;(scud hammer) (by GeoMan)
+scudhamm:
+0:fd1ea:3c:00:01
+
+;(super cup finals (world)) and clones (by GeoMan)
+scfinals:
+scfinalso:
+0:410f74:50:00:ff
+
+hthero93:
+cupfinal:
+hthero93u:
+0:410f60:50:00:ff
+
+;(sen jin - guardian storm (korea)) (by GeoMan)
+grdnstrmk:
+grdnstrm:
+redfoxwp2:
+grdnstrmv:
+redfoxwp2a:
+grdnstrmg:
+grdnstrmj:
+0:3c0300:3c:00:98
+
+;(shadow force (us) (by GeoMan)
+shadfrce:
+shadfrcejv2:
+shadfrcej:
+shadfrceu:
+0:1f002a:2:00:05
+0:1f002c:26:00:00
+0:1f0022:4:00:00
+
+;(sheriff) and clones (by GeoMan) 
+sheriff:
+bandido:
+westgun2:
+0:60f1:3:0:0
+
+;(sindbad mystery) (by GeoMan)
+sindbadm:
+0:e3a0:3c:00:4b
+0:c90b:3:00:00
+
+;(sonic blast man (japan)) (by GeoMan)
+sbm:
+0:10c000:2:00:73
+0:10c002:3e:01:00
+
+;(sos) (by GeoMan)
+sos:
+0:406c:2:0:0
+
+;(stagger i (japan)) (by GeoMan)
+stagger1:
+redhawkb:
+redhawke:
+redhawki:
+redhawk:
+redhawkk:
+0:3c0300:3c:00:98
+
+;(space tactics) (by GeoMan)
+stactics:
+0:d700:a:0:0
+0:e700:a:0:0
+0:f700:a:0:0
+
+;(space laser) and clones (by GeoMan) 
+spclaser:
+laser:
+0:2034:2:0:0
+0:205b:1:3d:3d
+0:2e70:4a1:0:0
+spcewarl:
+intruder:
+0:2034:2:0:0
+0:2058:1:9:9
+0:2e70:4a1:0:0
+
+;(space fortress) (by GeoMan)
+spacefrt:
+0:1c00:10:00:1b
+0:1c18:44:1b:00
+
+;(super bug) (by GeoMan)
+superbug:
+0:c:1:0:0
+
+;(super pinball action (japan)) (by GeoMan)
+spbactn:
+spbactnj:
+0:41780:32:00:05
+
+;(super stingray) (by GeoMan)
+sstingry:
+0:20028:4:00:73
+0:20770:90:00:00
+
+;(syusse oozumou (japan)) (by GeoMan)
+ssozumo:
+0:24:3:0:0
+0:714:74:42:40
+
+;(ring rage (world)) and clones (by GeoMan)
+ringrage:
+ringragej:
+ringrageu:
+0:40e660:30:00:4b
+0:40e690:280:53:00
+
+;********(power goal (world)
+pwrgoal:
+0:411aed:87:03:46
+
+;*********xain.c (xain`d sleena)(fix)
+xsleena:
+xsleenab:
+solarwar:
+solrwarr:
+xsleenaj:
+xsleenaba:
+0:33:3:00:00
+0:1bc7:3c:00:2c
+
+;*******(perfect soldiers (japan))
+psoldier:
+ssoldier:
+0:e1b0f:31:10:31
+0:e0032:1:06:06
+
+;*******(point blank)
+ptblank:
+ptblanka:
+0:21ccd4:64:00:09
+
+;*******(video pinball)
+videopin:
+0:37:1:00:00
+0:3c:1:00:00
+0:41:1:00:00
+
+;(gunbird 2) (by Paul Priest)
+gunbird2:
+0:604c758:28:00:70
+0:604c780:3c:1e:00
+
+;(sol divide) (by Paul Priest)
+soldivid:
+0:600bb50:18:00:50
+0:600bb68:1e:24:02
+
+;(strikers 1945 ii) (by Paul Priest)
+s1945ii:
+0:600c4ec:28:00:70
+0:600c514:3c:1e:00
+
+;*******(vampire savior 2: the lord of vampire (japan 970913)
+vsav2:
+vsav2d:
+0:fff426:1bf:00:03
+
+;(trick trap (world?)) and clones (by GeoMan)
+tricktrp:
+labyrunr:
+labyrunrk:
+0:22a0:40:00:53
+0:2308:4:0:0
+
+;(toryumon) (by GeoMan)
+toryumon:
+0:fffe20:28:0:0
+
+;(tactician) (by GeoMan)
+tactcian:
+0:98a8:3:0:0
+0:8048:140:00:10
+0:8028:20:00:10
+
+tactcian2:
+0:98a8:3:80:00
+0:8048:140:80:10
+0:8028:20:00:10
+
+;(top ranking stars (world new version)) and clones (by GeoMan)
+trstar:
+trstarj:
+trstaro:
+trstaroj:
+prmtmfgt:
+prmtmfgto:
+0:413d10:2:00:00
+0:413d12:7fe:13:00
+
+;(no man's land) (by GeoMan)
+nomnlnd:
+nomnlndg:
+0:6004:3:00:00
+0:6c5d:6c0:ff:00
+
+;(night driver) (by GeoMan) - Hiscore is updated when new game starts!
+nitedrvr:
+0:a0:c:0:0
+0:130:1:52:52
+
+;(namco classics vol. 1) and clones (by GeoMan) - ALL games MUST run through attract mode before starting a new game!
+ncv1:
+ncv1j:
+ncv1j2:
+0:400914:2ee:07:01
+
+;********(outfoxies)
+outfxiesj:
+outfxies:
+0:236210:3e:00:5f
+
+;********(oriental legend)
+orlegend:
+orlegende:
+orlegendc:
+0:811946:d4:49:b0
+
+orlegend105k:
+0:811918:d4:49:b0
+
+orlegend111c:
+orlegend111t:
+orlegend111k:
+0:81191e:d4:49:b0
+
+;********(kokontouzai eto monogatari (japan))
+eto:
+0:202d08:30:37:d0
+
+;********(golfing greats)
+glfgreat:
+0:100320:50:41:9
+0:100400:50:41:9
+
+;(metamoqester) (by GeoMan)
+metmqstr:
+0:f080e0:100:0a:01
+
+nmaster:
+0:f08100:e0:30:01
+
+;(major title 2 (world)) and clones (by GeoMan)
+majtitl2:
+skingame:
+skingame2:
+majtitl2b:
+0:ed542:140:4d:00
+
+majtitl2j:
+0:ed542:140:4b:00
+
+;(major league) (by GeoMan)
+mjleague:
+0:ffe000:50:00:20
+
+;(mighty guy) (by GeoMan)
+mightguy:
+0:c055:75:00:41
+
+;(many block) (by GeoMan)
+manybloc:
+0:f0050:4:00:19
+0:f0054:9c:00:00
+0:f03b2:6:0:0
+
+;********(hyper pacman (bootleg))
+hyperpacb:
+0:10535c:28:50:00
+0:10537e:1:43:43
+
+;********taito_f3.c (landmaker (japan))
+landmakr:
+landmakrp:
+0:40fc30:28:00:50
+
+;********nmk16.c (koutetsu yousai strahl (japan set 1))
+strahl:
+0:f30d9:18f:55:88
+0:f0d8a:4:00:50
+
+;********namcona1.c (knuckle heads (world))
+knckhead:
+knckheadj:
+0:209372:27:00:4c
+0:209373:1:10:10
+
+;(galactic warriors) (by GeoMan)
+gwarrior:
+0:1a4f6:50:00:01
+0:1f72f:3:00:85
+
+;(grand cross) (by GeoMan)
+gcpinbal:
+0:ff2318:2:00:02
+0:ff231a:6e:81:00
+0:ff000e:70:00:00
+
+;*******segac2.c (ichidant-r (puzzle_action 2 (english & japan)))
+ichirj:
+ichidnte:
+0:fffc3d:27:00:00
+
+;*******iqblock.c (iq-block)
+iqblock:
+0:f149:27:41:00
+0:f1a4:3:00:00
+0:f16e:1:13:13
+
+;*******epos.c (igmo) 
+;** only saves top score **
+igmo:
+0:784a:3c:10:00
+0:7805:1:f4:f4
+
+;*******megasys1.c (iga ninjyutsuden (japan))
+iganinju:
+0:f0004:4:00:00
+0:f4001:97:20:ac
+0:f0010:8:30:30
+
+;(recordbreaker (world)) (by GeoMan)
+recordbr:
+0:1034ee:1e0:00:45
+
+fghtatck:
+fa:
+0:1faa8:f2:00:03
+0:1122:4:0:0
+
+;(fast lane) (by GeoMan)
+fastlane:
+0:32a0:50:00:00
+0:3309:3:02:00
+
+;********xyonix.c (xyonix)
+xyonix:
+0:d500:13f:4f:00
+0:d639:1:08:08
+
+;********namcona1.c (cosmo gang the puzzle (us))
+cgangpzl:
+0:add2:ce:ff:a2
+
+cgangpzlj:
+0:20add2:ce:ff:a2
+
+;********supbtime.c (china town (japan))
+chinatwn:
+0:1a3e00:50:00:2e
+
+;********decocass.c (cassette: graplop (aka cluster buster(set 1))
+cgraplop:
+0:2a51:5d:43:30
+0:23:6:30:30
+
+demon: ;[Special thanks to Cananas for making this entry work]
+0:01c0:1e:00:10
+0:00b6:0a:00:01
+0:0000:0a:01:00
+
+;(dream soccer '94) and clones (by GeoMan)
+dsoccr94:
+0:eb57b:80:10:04
+dsoccr94j:
+0:ead6d:80:10:04
+dsoccr94k:
+0:eb7a1:80:10:04
+
+;(dynamic ski) (by GeoMan)
+dynamski:
+0:f092:46:00:1e
+0:f100:15:00:13
+0:f088:4:00:00
+
+;(dark warrior) (by GeoMan)
+darkwar:
+0:1e3e:20:0:0
+0:1e5e:3c:0:0
+0:1e9a:a:0:0
+
+;(dark planet) (by GeoMan)
+darkplnt:
+0:80b8:1e:00:4a
+0:80f4:1e:00:51
+
+;********system1.c (block gal (bootleg)
+blckgalb:
+0:c062:3:00:01
+
+barrier: ;[Special thanks to Cananas for making this entry work]
+0:0074:04:00:00
+0:00c0:06:00:00
+
+;********cinemat.c (boxing bugs)
+boxingb:
+0:e0:30:00:f4
+
+;********seta.c (blandia (prototype))
+blandiap:
+0:201056:62:09:17
+
+;********nmk16.c (black heart)
+blkheart:
+blkheartj:
+0:f9090:4:00:10
+
+;********mcr68.c (spy hunter 2 (rev 1 & 2))
+spyhunt2a:
+spyhunt2:
+0:60130:4:00:00
+0:600b3:1:32:32
+
+;(beraboh man (japan version c)) and clones (by GeoMan)
+berabohm:
+berabohmo:
+0:3f00:68:42:02
+
+;(sky chuter) (by GeoMan) - Hiscores are updated when game enters attract mode!
+skychut:
+0:7b:f:0:0
+0:406d:6:40:40
+
+;(tank busters) (by GeoMan)
+tankbust:
+0:f602:50:00:10
+
+;(space beam) (by GeoMan)
+spacbeam:
+0:c6:b:0:0
+0:0e:f:0:0
+
+;(formation z) and clones (by GeoMan)
+formatz:
+aeroboto:
+0:430:138:00:0f
+0:600:14:00:40
+
+;(angel kids (japan)) (by GeoMan)
+angelkds:
+0:c101:3:01:00
+0:c11b:118:01:20
+
+;(space seeker) (by GeoMan)
+spaceskr:
+0:83c0:3:0:0
+0:c46c:7:2e:00
+
+;******firetrk.c (fire truck)
+firetrk:
+0:28:1:06:06
+
+;********taito_f2.c (solitary fighter (world))
+solfigtr:
+0:102b80:49:00:24
+
+;*******(blasto)
+blasto:
+0:ff3a:5:30:30
+
+;(eco fighters (world 931203)) (by GeoMan)
+ecofghtrh:
+ecofghtr:
+ecofghtra:
+ecofghtru1:
+uecology:
+0:ff0339:a0:0a:00
+0:ff8106:4:00:00
+
+ecofghtru:
+0:ff033b:a0:0a:00
+0:ff8106:4:00:00
+ 
+;********psikyo.c (battle k-road (japan))
+btlkrodj:
+btlkroad:
+btlkroadk: 
+0:fe1af4:4e:00:04
+
+;********missb.c (miss bubble 2)
+missb2:
+0:e654:23:00:48
+0:e64c:3:00:00
+0:e64d:1:30:30
+
+;********renegade.c (nekketsu kouha kunio-kun (japan bootleg))
+kuniokunb:
+kuniokun:
+0:2e:3:00:05 
+0:102c:28:47:00 
+
+;********rockrage.c (rock `n rage (world?) 
+rockrage:
+rockragej:
+0:4980:4e:01:53
+0:48be:3:01:80
+0:4fc8:1:54:54 
+
+;******Rock 'n Rage (Prototype?)
+rockragea:
+0:4980:4e:01:53
+0:48be:3:01:80
+0:4866:1:03:03
+
+;********galaxian.c (zero time)
+zerotime:
+0:40a8:3:00:00
+ 
+;(scrambled egg) and clones (by GeoMan)
+scregg:
+eggs:
+0:400:1e:17:00
+0:015:3:00:03
+
+;(scorpion (bootleg on galaxian hardware)) (by GeoMan)
+scorpng:
+0:4207:f:00:00
+0:42ad:f:10:10
+
+;(sauro) (by GeoMan) 
+sauro:
+saurop:
+0:e000:b4:00:4f
+ 
+;(sasuke vs. commander) (by GeoMan)
+sasuke:
+0:24:2:00:05
+
+;(samurai (sega)) (by GeoMan)
+samurai: 
+0:971a:12:00:00
+
+;(safari rally) (by GeoMan) - hiscore updates after new game start !!!
+safarir:
+safarirj:
+0:2389:3:00:00
+0:2381:3:00:00
+0:2141:1:20:20 
+0:2161:1:20:20
+0:2181:1:20:20 
+0:21a1:1:20:20
+0:21c1:1:20:20
+0:21e1:1:20:20
+ 
+;(sadari) (by GeoMan)
+sadari: 
+0:c31d:3c:3a:01
+
+;(riding fight (world)) and clones (by GeoMan)
+ridingf: 
+ridingfu: 
+ridingfj: 
+0:408060:80:00:3f
+ 
+;(reikai doushi (japan)) 
+reikaids:
+0:43ca:1e:00:e8
+0:40df:2:13:88
+
+;(red alert) (by GeoMan)
+redalert:
+0:301:f:0:0
+ 
+;(raiders5) and clones (by GeoMan)
+raiders5:
+raiders5t: 
+0:e075:37:00:55
+0:888c:7:22:10
+
+;(rafflesia) (by GeoMan)
+raflesia:
+0:d300:50:00:4a
+0:c017:3:00:02
+
+;(puzzle de bowling (japan)) (by GeoMan)
+pzlbowl:
+0:20a9c4:60:0a:a8
+ 
+;(punk shot (us 4 players)) and clones (by GeoMan)
+punkshot: 
+punkshotj:
+punkshot2:
+0:80700:30:00:40
+
+;(power surge) (by GeoMan) - Hiscores appear correctly after game enters attract mode!
+psurge: 
+0:a86c:6:20:30 
+0:b080:50:31:ff
+
+;(pop flamer (protected)) and clones (by GeoMan)- hiscore updates after new game start !!! 
+popflame:
+popflamea:
+popflameb:
+popflamen: 
+0:4004:3:0:0
+0:4021:3:0:0
+0:872f:1:20:20
+0:8733:1:20:20
+0:8737:1:20:20 
+0:873b:1:20:20
+0:873f:1:20:20
+0:8743:1:20:20
+
+;(pocket gal (japan)) and clones (by GeoMan)
+pcktgal:
+pcktgalb:
+pcktgal2:
+spool3: 
+spool3i: 
+pcktgal2j:
+0:0467:2:64:00
+
+pballoon:
+pballoonr:
+0:0220:70:11:30
+0:0022:3:00:00
+ 
+;(pettan pyuu (japan)) (by GeoMan)
+pettanp: 
+0:c0c2:1e:20:00
+
+;********slapfght.c - ADDED CLONE
+perfrman: 
+perfrmanu:
+0:8006:30:89:12
+0:8609:07:24:00
+
+;(percussor, the) (by GeoMan)
+percuss: 
+0:5da8:37:00:24
+ 
+;********************************************************************************
+;* latest unofficial highscore_v7.93 additions below - by leezer/geoman/others  *
+;********************************************************************************
+
+;(peek-a-boo!) (by GeoMan)
+peekaboo:
+peekaboou:
+0:1f0278:60:00:fa
+0:1f0380:4:00:00
+ 
+;(pass) (by GeoMan)
+pass:
+0:81200:50:4b:00
+0:8005e:4:00:00
+ 
+;(paddle mania) (by GeoMan)
+paddlema:
+0:801a8:28:02:03
+0:82108:a0:00:20
+
+;(onna sansirou - typhoon gal (set 1)) and clones (by GeoMan)
+onna34ro: 
+onna34roa:
+0:e1d7:82:00:65 
+0:e188:3:00:01
+ 
+;(noboranka (japan)) (by GeoMan)
+nob:
+nobb:
+0:d300:3c:00:2e
+0:f000:3:00:00
+
+;(ninjakun majou no bouken) (by GeoMan)
+ninjakun:
+0:e0a3:37:00:20
+0:c08c:7:22:10
+ 
+;(ninja kid ii (set 1)) and clones (by GeoMan) 
+ninjakd2:
+ninjakd2a: 
+ninjakd2b: 
+rdaction:
+ninjakd2c:
+0:e0f4:3:00:00
+0:e04e:64:31:20
+
+columns:
+columnsj:
+columns2:
+column2j:
+0:fffc1f:90:55:00
+
+;(new sinbad 7) (by GeoMan)
+newsin7: 
+newsin7a:
+0:43d3:48:00:10
+0:413d:3:0:0
+
+;(navalone) (by GeoMan)
+navalone:
+navarone: 
+0:402d:3:0:0
+
+;(nato defense) and clones (by GeoMan)
+natodef:
+natodefa:
+0:8df6:49:30:20
+
+;(nastar (world)) and clones (by GeoMan)
+nastar:
+nastarw:
+rastsag2:
+0:601eef:3a:00:42
+0:600545:3:00:77
+ 
+;(hexion (japan)) (by GeoMan)
+hexion: 
+hexionb:
+0:a740:3:00:10
+0:a743:27d:00:00
+
+;*******gotya.c (got-ya (12/241981,prototype ?)) - ADDED CLONE
+gotya:
+thehand: 
+0:5021:3:00:01
+
+;******cvs.c (radar zone - ADDED CLONE)
+outline:
+radarzon:
+radarzon1: 
+radarzont: 
+0:1c08:35:00:00
+
+;(invinco) (by GeoMan)
+invinco:
+0:8398:16:00:00
+ 
+;(invinco / head on 2) (by GeoMan)
+invho2:
+0:83b6:16:00:00 
+0:8392:12:30:30
+
+;(kaos) (by GeoMan)
+kaos: 
+0:03c8:30:84:44
+
+;(ken-go) (by GeoMan)
+kengo: 
+kengoa:
+ltswords:
+0:e09f2:82:10:20
+ 
+;(kodure ookami (japan)) (by GeoMan)
+kodure: 
+0:637c0:4:00:00 
+0:635b4:28:00:00
+
+;(knuckle bash) (by GeoMan)
+kbash:
+kbashk:
+0:100080:3c:00:30 
+
+;(knuckle joe (set 1)) and clones (by GeoMan)
+kncljoe:
+kncljoea:
+bcrusher:
+0:f01a:2d:00:43
+
+;(kuri kinton (world)) and clones (by GeoMan)
+kurikint:
+kurikintu:
+kurikintj:
+kurikinta:
+0:8aa3:a0:00:2e
+ 
+;(legend of makai (world)) and clones (by GeoMan)
+lomakai:
+makaiden: 
+0:ff000:2:00:03 
+0:ff002:7e:00:00 
+0:fe060:4:00:00
+ 
+;(kyros) (by GeoMan)
+kyros: 
+kyrosj:
+0:20e00:ae:01:02 
+0:20020:4:00:00
+
+;(lizard wizard) (by GeoMan)
+lizwiz: 
+0:4daf:3c:4d:01
+0:43ed:6:00:40
+
+;(lost tomb (easy)) and clones (by GeoMan) 
+losttomb: 
+losttombh: 
+0:8110:50:03:00
+
+;(mach rider) (by GeoMan)
+machridr:
+0:0714:50:00:4b
+ 
+;(mad crasher) (by GeoMan)
+madcrash:
+0:c2b3:4b:00:4b
+
+;(magical spot ii) (by GeoMan)
+magspot2:
+0:6007:2:00:20 
+0:6009:1:00:00
+
+;(megatack) (by GeoMan)
+megatack:
+0:00c4:f:00:1a
+
+;(minefield) (by GeoMan) 
+minefld:
+0:80f3:3c:01:43
+minefldfe:
+0:ef3:3c:03:50
+ 
+;(bucky o'hare (world version ea) and clones (by GeoMan) 
+bucky:
+buckyuab:
+buckyaab:
+buckyea:
+0:801e0:50:00:04
+ 
+;(mister viking) and clones (by GeoMan)
+mrviking:
+mrvikngj: 
+0:d42c:15:59:47
+0:d300:15:00:01 
+0:c086:3:00:02
+ 
+;(money money) (by GeoMan)
+monymony:
+0:7512:48:0a:00
+0:726d:3:00:00
+ 
+;(mystic raiders (world)) and clones (by GeoMan)
+mysticri:
+gunhohki:
+0:e8af8:38:00:4d 
+0:e8b30:94:2e:00
+
+;(mysterious stones) (by GeoMan)
+mystston:
+myststono:
+myststonoi:
+0:0308:37:00:0c
+0:001a:5:00:00 
+0:1033:8:40:41
+ 
+;(cyberbots: fullmetal madness (japan 950420)) (by GeoMan)
+cybots: 
+cybotsj:
+cybotsu:
+cybotsjd:
+cybotsud:
+0:ffe6a0:5:00:43
+0:ffe6a5:4b:41:00
+ 
+;(space trek (upright)) and clones (by GeoMan) 
+spacetrk:
+spacetrkc:
+0:838c:4:0:0
+
+spacezap: 
+0:d00f:1:ff:ff 
+0:d041:6:0:0 
+0:d01d:6:0:0
+
+
+;(american speedway (set 1)) and clones (by GeoMan)- * UNDER TEST *
+amspdwy: 
+amspdwya:
+0:e402:190:50:00 
+0:e602:190:50:00 
+0:e3de:23:00:5c
+ 
+;(speed ball) (by GeoMan) 
+speedbal: 
+0:f800:46:20:50
+
+;(speed freak) (by GeoMan)
+speedfrk:
+0:128:2:0:0
+ 
+;(spinal breakers (world)) and clones (by GeoMan) 
+spinlbrk: 
+spinlbrku: 
+0:ffac76:8c:00:50 
+spinlbrkj:
+0:ffacce:8c:00:50
+ 
+;(sports match) (by GeoMan)
+sprtmtch: 
+0:7500:30:4a:00 
+0:7743:2:00:00
+
+;(s.r.d. mission) (by GeoMan)
+srdmissn:
+fx:
+0:e6ef:5f:00:ff
+
+;(star jacker (sega)) and clones (by GeoMan)
+starjack:
+0:c0e1:1e:00:52 
+0:c0db:3:00:03
+
+starjacks:
+0:c102:23:00:52
+0:c0fb:4:00:00
+
+;(strength & skill) and clones (by GeoMan)
+strnskil:
+guiness: 
+0:c0c4:1e:22:00
+0:c430:60:09:00
+ 
+;(super bond) (by GeoMan)
+superbon:
+0:810f:50:00:48
+
+;(super invader attack) (by GeoMan)
+sia2650: 
+tinv2650: 
+0:1d07:2:0:0
+0:19fa:1:30:30 
+0:1a1a:1:30:30
+0:1a3a:1:30:30
+0:1a5a:1:30:30
+ 
+;(superbike) (by GeoMan) 
+superbik: 
+0:1c08:1e:00:30
+
+;(syvalion (japan)) (by GeoMan)
+syvalion:
+0:1090ec:10:00:01 
+0:1090fc:54:49:00 
+0:104266:4:00:00
+
+;(tailgunner) (by GeoMan)
+tailg:
+0:d8:4:0:0
+
+;(tecmo knight) and clones (by GeoMan)- hiscores update after hiscore table is displayed in attract mode
+tknight: 
+wildfang: 
+wildfangs:
+0:609ce:28:00:1a
+ 
+;(time limit) (by GeoMan) 
+timelimt:
+0:80ca:3:0:0 
+0:8981:1:27:27
+0:89a1:1:00:00 
+0:89c1:1:27:27
+0:89e1:1:27:27
+0:8a01:1:27:27 
+0:8a21:1:27:27
+ 
+;(time tunnel) (by GeoMan) 
+timetunl:
+0:801f:6:0:0
+0:c46d:6:63:63
+
+;(toki no senshi - chrono soldier) (by GeoMan)
+tokisens:
+0:c04d:54:00:20
+0:c0a1:4:00:00
+
+;(tough turf (japan)) and clones (by GeoMan) 
+tturf:
+tturfu:
+tturfbl:
+0:200100:4:00:08
+0:200104:7c:08:00
+ 
+;(ultraman club - tatakae! ultraman kyoudai!!) (by GeoMan)
+umanclub: 
+0:200742:2:00:07
+0:2006a2:a0:00:00 
+
+;(valkyrie no densetsu (japan)) (by GeoMan)
+valkyrie: 
+0:100620:4:00:a0 
+0:100624:9c:56:00
+
+;(vanguard ii) (by GeoMan) 
+vangrd2:
+0:c380:60:0a:00
+0:f620:3:00:00
+ 
+;(vastar (set 1)) and clones (by GeoMan) 
+vastar: 
+vastar2:
+vastar3:
+vastar4:
+0:cda1:1:00:00
+0:cdc1:1:00:00 
+0:cde1:1:00:00 
+0:ce01:1:00:00
+0:ce21:1:02:02 
+0:ce41:1:28:28 
+0:ce61:1:28:28 
+0:f128:85:00:16 
+
+;(wai wai jockey gate-in!) (by GeoMan) 
+wwjgtin:
+0:0220:70:24:24 
+0:001c:3:00:00
+
+;(wall street) (by GeoMan) 
+wallst:
+0:1c19:1e:00:00
+
+;(water match) (by GeoMan)
+wmatch: 
+0:c000:3c:84:02 
+0:c086:3:00:02 
+0:d300:15:00:01 
+0:d380:15:41:49 
+0:d400:2d0:84:4d
+
+;(water ski) (by GeoMan)
+waterski: 
+0:835b:3:0:0
+
+;(capcom sports club (japan 970722)) and clones (by GeoMan) 
+csclubj:
+cscluba:
+csclub:
+csclub1:
+csclubh:
+csclubjy:
+csclub1d:
+0:ff9894:50:00:b2 
+0:ff98e4:dc:1a:01 
+
+;(in the hunt (world)) and clones (by GeoMan) - FIXED ENTRY! 
+inthunt:
+inthuntu:
+kaiteids:
+0:e0180:d8:00:02
+ 
+;********system16.c (wonder boy iii - monster lair (set 1))
+wb3bbl:
+wb32:
+wb31:
+wb34:
+wb3:
+wb33:
+wb35:
+wb35a:
+wb31d:
+wb32d:
+wb33d:
+wb34d:
+wb35d:
+0:ffc8b8:28:4c:00
+0:ffc8de:1:30:30
+
+;******wonder boy III - monsters lair (japan,system 16b, fd1094 317-0085)	
+wb3bb:
+0:ff08b8:27:4c:30
+
+;********system16.c (wonder boy 3 (bootleg))
+wb3bl:
+0:ffc8b8:28:4c:00
+0:ffc8de:1:30:30
+
+;********vicdual.c (pulsar)
+pulsar:
+0:85f4:39:50:50
+
+;********galspnbl.c (hot pinball)
+hotpinbl:
+0:801780:30:00:09
+0:800007:1:03:03
+
+;********dooyong.c (gun dealer `94)
+gundl94:
+primella:
+0:c322:3a:41:01
+
+;(karate tournament, the) (by GeoMan)
+karatour:
+karatourj:
+0:ffd4fe:c0:62:01
+
+;(hebereke no popoon (japan)) (by GeoMan)
+heberpop:
+0:304920:a0:00:1c
+
+;(hasamu (japan)) (by GeoMan)
+hasamu:
+0:a3115:105:00:04
+
+;(hal21) and clones (by GeoMan)
+hal21:
+hal21j:
+0:fe6b:3c:00:41
+0:fce1:3:00:00
+
+;(gypsy juggler) (by GeoMan) - Hiscore displays correctly after a new game starts!
+gypsyjug:
+0:0e00:5:00:00
+0:0e23:1:0e:0e
+
+;(guzzler) (by GeoMan)
+guzzler:
+guzzlers:
+0:8584:50:00:55
+0:8007:6:00:00
+
+;(dead eye) (by GeoMan) - Hiscore displays correctly after a new game starts!
+deadeye:
+0:0e00:6:0:0
+0:0e2a:1:20:20
+
+;********twin16.c (missing in action (version t))
+mia:
+miaj:
+mia2:
+0:62100:4f:00:54
+0:6012a:4:00:30
+
+;********taito_f2.c (mega blast (world))
+megablst:
+megablstj:
+megablstu:
+0:203f38:32:00:52
+0:2043ea:4:00:00
+0:2043eb:1:08:08
+
+;********mugsmash.c (mug smashers)
+mugsmash:
+0:1c01c4:e:03:d2
+0:1c00b4:4f:2e:20
+
+;(gulf storm) and clones (by GeoMan)
+gulfstrm:
+gulfstrmm:
+gulfstrma:
+gulfstrmb:
+0:c580:80:00:2e
+0:c618:4:00:00
+
+;(grand champion) (by GeoMan)
+grchamp:
+0:4215:f:0:0
+
+;(goindol) and clones (by GeoMan)
+goindol:
+homo:
+goindolk:
+goindolu:
+0:c0d8:2:05:00
+0:c076:50:05:59
+
+;(funny mouse) parent
+funnymou:
+0:804A:03:00:00
+0:9221:01:24:24
+0:9201:01:24:24
+0:91E1:01:24:24
+0:91C1:01:24:24
+0:91A1:01:24:24
+0:9181:01:00:00
+
+;(funky fish) (by GeoMan)
+fnkyfish:
+0:e030:9:0:0
+
+;(funky bee) (by GeoMan)
+funkybee:
+funkybeeb:
+0:828b:2d:00:0c
+
+frogs: ;[Special thanks to Cananas for enhancing this entry]
+0:e508:06:00:00
+0:e037:06:00:30
+
+;(freeze) (by GeoMan)
+freeze:
+0:4b90:50:f4:00
+
+;(robotron) and clones (by GeoMan) - Changing DIP switch settings resets the Daily heroes table (ONLY)!
+;robotron:
+;robotronyo:
+;0:cf6e:8c:04:10
+
+;********destroyr.c (destroyer)
+;** hiscore updates once first game is over **
+destroyr:
+0:dd:2:00:00
+0:e0:1:00:00
+
+;********turbo.c (subroc3d)
+;** top score updates after hiscore displayed in attract mode **
+subroc3d:
+0:e400:3e:00:00
+0:b049:1:f6:f6
+
+;********lemmings.c (lemmings (us prototype))
+lemmings:
+0:10a402:50:44:01
+
+;(football champ (world)) and clones (by GeoMan)
+footchmp:
+hthero:
+0:10a920:50:0a:00
+euroch92:
+0:10a99c:50:0a:00
+
+;(i'm sorry (us)) and clones (by GeoMan)
+imsorry:
+imsorryj:
+0:c017:3:00:02
+0:d300:a0:00:20
+
+;(ninja gaiden (world)) clones
+shadoww:
+ryukendn:
+shadowwa:
+gaiden:
+mastninj:
+ryukendna:
+0:62e34:d0:2e:00
+0:62e47:1:09:09
+
+;(flash gal) (by GeoMan)
+flashgal:
+flashgala:
+0:f690:5e:00:40
+
+;(fire one) (by GeoMan)
+fireone:
+0:831a:5a:00:24
+
+;(enduro racer (bootleg set 2)) clone (by GeoMan)
+endurob2:
+0:043400:54:01:00
+
+;(dynamite duke) and clones (by GeoMan)
+dynduke:
+dyndukef:
+dyndukej:
+dyndukeu:
+0:1346:77:50:2a
+dbldyn:
+dbldynj:
+dbldynu:
+dbldynf:
+0:155c:8c:50:00
+
+;(devil zone) (by GeoMan)
+devzone:
+devzone2:
+0:7ec0:5b:1e:26
+0:6007:3:0:0
+
+;(devil fish) parent
+devilfsh:
+0:40a8:3:0:0
+
+;(hammerin' harry (world)) clones (by GeoMan)
+dkgensanm72:
+0:a09a0:9f:40:20
+0:a0a40:03:40:02
+
+;(cutie q) (by GeoMan)
+cutieq:
+0:2215:c:00:01
+
+;********metro.c (pururun)
+pururun:
+0:80f2b8:4b:00:85
+
+;********ninjaw.c (the ninja warriors (world))
+ninjaw:
+ninjawj:
+ninjawu:
+0:c4645:3f8:01:47
+
+;********vicduel.c (invinco/deep scan)
+; ** player scores from last game played also saved - no big deal !!  **
+invds:
+0:8398:e6:00:09
+
+;*************************************************************************
+;* latest unofficial highscore_v7.92 additions below - by leezer/geoman  *
+;*************************************************************************
+;********metro.c (puzzli)
+puzzli:
+0:80eabc:4c:00:4f
+
+;********taito_b.c (hit the ice (us))
+;** you must wait untill the hiscore table has displayed in attract mode before **
+;** starting a game, for the save to work ** 
+hitice:
+0:802830:27:00:4b
+0:802852:1:56:56
+
+;********m92.c (gunforce 2)
+gunforc2:
+geostorm:
+0:ea5ae:4b:00:a6
+
+;********sharrier.c (enduro racer (bootleg set 1))
+endurobl:
+0:43400:4a0:01:20
+0:43b90:10:99:99
+
+;********cicsheat.c (big run (11th rallye version))
+bigrun:
+0:f61da:2bc:50:05
+
+;(crude buster (world fx version)) and clones (by GeoMan)
+cbuster:
+cbusterw:
+cbusterj:
+0:80080:28:01:00
+twocrude:
+twocrudea:
+0:80080:28:01:00
+0:800c0:28:41:00
+
+;(bounty, the) (by GeoMan)
+bounty:
+0:b1ba:6:0:0
+0:b23a:6:0:0
+0:b2ba:6:0:0
+0:b19a:6:26:27
+0:b21a:6:26:27
+0:b29a:6:26:27
+
+;(bottom of the ninth (version t)) and clones (by GeoMan)
+bottom9:
+bottom9n:
+mstadium:
+0:4176:82:41:70
+
+;(bomb bee) (by GeoMan)
+bombbee:
+0:2214:5:00:01
+
+;(bogey manor) (by GeoMan)
+bogeyman:
+0:0021:3:00:01
+0:13e0:29:00:1e
+0:1409:27:0f:00
+
+;(block hole) and clones (by GeoMan)
+blockhl:
+quarth:
+0:4163:44:00:05
+
+;(bio attack) (by GeoMan)
+bioatack:
+0:800e:2:00:50
+0:8010:1:00:00
+
+;(black hole) (by GeoMan)
+blkhole:
+0:4140:9:58:00
+
+;********stlforce.c (steel force)
+stlforce:
+0:105772:32:4e:00
+0:105784:1:02:02
+
+;(big pro wrestling!,the) (by GeoMan)
+bigprowr:
+tagteam:
+0:406:12c:00:19
+0:32:3:00:05
+
+;(big karnak) (by GeoMan)
+bigkarnk:
+0:102086:a0:00:0a
+0:ff801e:4:00:80
+
+;(beezer (set1)) (by GeoMan)
+beezer:
+0:0507:50:55:00
+
+;(beezer (set2)) clone - modified hiscore save (by GeoMan)
+beezer1:
+0:0503:50:55:00
+
+;(battlantis) (battlantis (japan)) (by GeoMan)
+battlnts:
+battlntsj:
+battlntsa:
+0:1050:4:0:0
+0:1100:50:00:52
+
+;(back street soccer) (by GeoMan)
+bssoccer:
+bssoccera:
+0:200e90:28:41:00
+
+;********warriorb.c (warrior blade (japan))
+warriorb:
+0:202a38:ef:50:00
+0:202b25:1:01:01
+
+;********cps2.c (rockman 2 : the power fighters (japan 960708))
+rockman2j:
+rckman2jregion:
+0:ffefc0:118:00:02
+0:fff047:1:01:01
+
+;Skull & Crossbones (set2) clone
+;skullxb2:
+;skullxbo:
+;skullxb1:
+;skullxb3:
+;skullxb4:
+;0:fff568:100:6f:00
+;0:fff666:1:54:54
+
+;Saturday Night Slam Masters clones
+slammastu: 
+0:ffa138:02:00:10
+0:ffa13a:ae:00:00
+
+;Robocop clones
+robocopw:
+robocopj:
+robocopu:
+robocopu0:
+0:ff8ed8:a0:4d:00
+0:ffb522:4:00:00
+0:ffb523:1:05:05
+
+;*******dec0.c (robocop (world revision 4))
+robocop:
+0:ff8ed8:a0:4d:00
+0:ffb522:4:00:00
+0:ffb523:1:05:05
+
+robocopb:
+automat:
+0:ff8ed8:a0:4d:00
+0:ffb522:1:00:00
+0:ffb523:1:05:05
+0:ffb524:2:00:00
+
+;Puzzle Bobble 4 clones
+pbobble4j:
+pbobble4u:
+0:40e85a:116:00:00
+0:40e8ba:1:41:41
+
+gijoe:
+gijoeu:
+gijoej:
+gijoea:
+0:18f900:f8:41:01
+
+;Elevator Action 2 clones
+elvact2u:
+elvactrj:
+0:40ce3a:7c:00:01
+0:40ce3c:1:c3:c3
+
+galpanic:
+galpanib:
+0:53e728:50:30:31
+
+;Double Dragon 2 clones
+ddragon2u:
+0:0f91:1e:02:23
+0:0023:3:02:00
+
+ddragon2:
+ddragon2b:
+0:0f91:1e:02:23
+0:0023:3:02:00
+
+;CamelTry clones
+cameltryau:
+cameltryj:
+cameltrya:
+0:106c9e:244:35:44
+0:1066b0:3e:06:00
+0:105430:4:00:00
+
+;Wonder Momo (by GeoMan)
+wndrmomo:
+0:4e00:45:0:2f
+
+;Youjyudn (Japan) (by GeoMan)
+youjyudn:
+0:e565:37:70:4e
+
+;ZeroHour (by GeoMan)
+zerohour:
+zerohoura:
+zerohouri:
+0:3023:4:0:0
+
+;Devastators clones
+devstors2:
+devstors3:
+garuka:
+0:41c4:2e:01:01
+
+;Main Event (by GeoMan)
+mainevt:
+mainevt2p:
+ringohja:
+mainevto:
+0:415d:45:ae:77
+
+;Markham (by GeoMan)
+markham:
+0:c0c4:3c:2a:00
+
+route16bl:
+route16a:
+routex:
+0:4032:9:0:0
+
+;********route16.c
+route16:
+route16c:
+0:4032:9:00:00
+
+;Moguchan (by GeoMan)
+moguchan:
+0:5eda:6:0:0
+
+;Naughty Boy clones (by GeoMan) - score updates after game start !!!
+naughtya:
+naughtyc:
+0:4004:3:0:0
+0:8733:1:20:20
+0:8737:1:20:20
+0:873d:1:20:20
+0:873f:1:20:20
+0:8743:1:20:20
+
+;in this game to make the hiscore display by starting a new game (if you beat the hiscore) before you exit
+naughtyb: 
+naughtyba:
+naughtybc:
+0:4004:3:0:0
+0:4021:3:0:0
+0:872f:1:20:20
+0:8733:1:20:20
+0:8737:1:20:20
+0:873b:1:20:20 
+0:873f:1:20:20 
+0:8743:1:20:20
+
+;Video Hustler and clones (by GeoMan)
+hustlerb:
+billiard:
+vpool:
+hustlerd:
+0:84c0:e:0:0
+0:80a8:3:0:2
+
+;*********scobra.c (video hustler)
+hustler:
+hustlerb3:
+hustlerb4:
+0:84c0:f:00:00
+0:80a8:3:00:02
+0:8003:1:0a:0a
+
+;Moonwar and clones (by GeoMan)
+moonwar:
+moonwara:
+0:80f2:3c:02:4c
+
+;********taito_f3.c (lightbringer (japan))
+;** you must wait until the hiscore table has displayed in attract mode before **
+;** starting a game, for the save to work ** 
+lightbr:
+lightbrj:
+0:40a312:70:00:01
+
+;********lsasquad.c (land sea air squad / riku kai kuu saizensen)
+lsasquad:
+0:a814:3:00:01
+0:a46c:70:68:00
+0:d754:d:20:30
+
+storming:
+0:a814:3:00:01
+0:a46c:70:69:00
+0:d754:d:20:30
+
+;********namcos2.c (marvel land (us))
+marvland:
+0:106100:28:00:03
+0:40b650:4:00:00
+
+;********m92.c (undercover cops (world))
+uccops:
+uccopsu:
+0:e3e9a:49:30:01
+
+uccopsj:
+uccopsar:
+0:e3e7c:49:30:01
+
+;********seta.c (wits (japan))
+wits:
+0:ffd6c2:49:00:4b
+
+;********decocass.c (cassette: pro bowling)
+cprobowl:
+0:33:24:50:13
+0:36:1:50:50
+
+;********taito_z.c (space gun (world))
+spacegun:
+spacegunj:
+spacegunu:
+0:318d74:97:00:58
+
+;********system16.c (riot city)
+riotcity:
+0:ffce00:3f:00:45
+
+;********system1.c (regulus (new ver))
+regulus:
+reguluso:
+regulusu:
+0:ce40:1e:41:4a
+0:c0e1:3:00:00
+0:cd01:1e:00:00
+
+;********leland.c (cerberus)
+;** only seems to save top score **
+cerberus:
+0:e83b:ba:27:00
+0:e004:1:1b:1b
+
+;********galaxian.c (omega)
+omega:
+0:43c0:0f:00:00
+0:40a8:03:00:00
+
+;********wgp.c (world grand prix (us & joystick version set 1 japan)
+;** you must wait untill the hiscore table has displayed in attract mode before **
+;** starting a game, for the save to work ** 
+;** THIS SAVE DOES NOT SAVE THE COURSE RECORDS **
+wgp:
+0:10bbd9:c5:01:02
+0:10bc9b:1:44:44
+
+wgpjoy:
+0:10bbdd:c5:01:02
+0:10bc9f:1:44:44
+
+;********deco.c (sly spy (us revision 3))
+slyspy:
+slyspy3:
+secretag:
+slyspy2:
+0:306adc:4:00:00
+0:304000:9f:00:33
+0:306add:1:30:30
+
+secretagj:
+0:306c16:4:00:00
+0:304000:9f:00:33
+0:306c17:1:30:30
+
+;********taito_z.c (double axle (us))
+dblaxle:
+0:202c91:18f:13:10
+
+;********taito_f3.c (cleopatras fortune (japan))
+;** you must wait untill the hiscore table has displayed in attract mode before **
+;** starting a game, for the save to work **
+cleopatr:
+0:412de4:78:00:4a
+
+;***************************************************************
+;* latest :highscore_v7.91 additions below - by leezer         *
+;***************************************************************
+;*******namcos2.c (mirai ninja (japan))
+mirninja:
+0:100400:d0:4d:00
+0:1004ce:1:10:10
+
+;********seta.c (gundhara)
+gundhara:
+gundharac:
+0:20f908:33:00:6e
+
+;********nmk16.c (gunnail)
+gunnail:
+0:faf00:6e:00:49
+0:fa800:78:00:55
+0:fe004:f93:00:50
+
+;********galaxian.c (sky base)
+;** if you beat the top score don`t exit game until it is displaying in **
+;** the top centre of the screen **
+skybase:
+0:803a:36:00:00
+0:8000:1:14:14
+0:91a1:1:00:00
+0:91c1:1:00:00
+0:91e1:1:00:00
+0:9201:1:05:05
+0:9221:1:00:00
+0:9241:1:00:00
+
+;********dcon.c (sd gundam psycho salamander no kyoui)
+;** for some reason you have to press key 9 to insert credits **
+;** game (driver ??) related problem - not hiscore.dat **
+sdgndmps:
+0:8b600:9c:00:1a
+
+;********popper.c (popper)
+;** do not reset this game - it screws up the hiscore & hiscore saving **
+popper:
+0:c700:3c:4f:00
+0:db2b:3:00:01
+0:c1ed:6:00:20
+0:c8ca:1:19:19
+
+;********carjmbre.c (car jamboree)
+carjmbre:
+0:820a:a0:00:45
+0:8217:1:30:30
+
+;*******ssv.c (monster slider (japan))
+mslider:
+0:2acc:a8:00:02
+0:c0:1:15:15
+
+;*******mosaic.c (mosaic)
+mosaic:
+0:201e7:50:54:00
+0:20235:1:05:05
+
+;********cave.c (air gallet (taiwan))
+agallet:
+agalleth:
+agalletj:
+agalletk:
+agallett:
+agalletu:
+0:100292:5a:00:00
+0:100200:2:02:1a
+
+;********skykid.c (dragon buster)
+drgnbstr:
+0:485a:3:00:00
+0:485b:1:10:10
+0:406c:7:2f:00
+0:406e:1:01:01
+
+;********shangha3.c (blocken (japan))
+blocken:
+0:3086ec:4f:00:57
+
+;********z80bw.c (astro invader)
+;** god, the things i do to give y`all these hiscore saves !! **
+;** is this the longest hiscore.data yet ? **
+astinvad:
+0:1fca:14:00:00
+0:2f1d:1:3e:3e
+0:2f3d:1:41:41
+0:2f5d:1:41:41
+0:2f7d:1:41:41
+0:2f9d:1:3e:3e
+0:301d:1:3e:3e
+0:303d:1:41:41
+0:305d:1:41:41
+0:307d:1:41:41
+0:309d:1:3e:3e
+0:311d:1:3e:3e
+0:313d:1:41:41
+0:315d:1:41:41
+0:317d:1:41:41
+0:319d:1:3e:3e
+0:321d:1:3e:3e
+0:323d:1:41:41
+0:325d:1:41:41
+0:327d:1:41:41
+0:329d:1:3e:3e
+0:331d:1:3e:3e
+0:333d:1:41:41
+0:335d:1:41:41
+0:337d:1:41:41
+0:339d:1:3e:3e
+
+kosmokil:  ;******Kosmo Killer
+0:1fc4:14:00:00
+0:2f1d:1:3e:3e
+0:2f3d:1:41:41
+0:2f5d:1:41:41
+0:2f7d:1:41:41
+0:2f9d:1:3e:3e
+0:301d:1:3e:3e
+0:303d:1:41:41
+0:305d:1:41:41
+0:307d:1:41:41
+0:309d:1:3e:3e
+0:311d:1:3e:3e
+0:313d:1:41:41
+0:315d:1:41:41
+0:317d:1:41:41
+0:319d:1:3e:3e
+0:321d:1:3e:3e
+0:323d:1:41:41
+0:325d:1:41:41
+0:327d:1:41:41
+0:329d:1:3e:3e
+0:331d:1:3e:3e
+0:333d:1:41:41
+0:335d:1:41:41
+0:337d:1:41:41
+0:339d:1:3e:3e
+
+kamikaze:
+0:1fc5:14:00:00
+0:2f1d:1:3e:3e
+0:2f3d:1:41:41
+0:2f5d:1:41:41
+0:2f7d:1:41:41
+0:2f9d:1:3e:3e
+0:301d:1:3e:3e
+0:303d:1:41:41
+0:305d:1:41:41
+0:307d:1:41:41
+0:309d:1:3e:3e
+0:311d:1:3e:3e
+0:313d:1:41:41
+0:315d:1:41:41
+0:317d:1:41:41
+0:319d:1:3e:3e
+0:321d:1:3e:3e
+0:323d:1:41:41
+0:325d:1:41:41
+0:327d:1:41:41
+0:329d:1:3e:3e
+0:331d:1:3e:3e
+0:333d:1:41:41
+0:335d:1:41:41
+0:337d:1:41:41
+0:339d:1:3e:3e
+
+;********taito_f2.c (dino rex (world & us))
+dinorex:
+dinorexj:
+dinorexu:
+0:602760:90:00:4f
+
+;********megasys1.c (cybattler)
+cybattlr:
+0:1f0101:ed:02:20
+
+;********karnov.c (chelnov - atomic runner (us))
+chelnovu:
+0:060048:04:00:00
+0:060080:2C:00:00
+0:0600C0:2C:41:00
+
+chelnov:
+chelnovj:
+chelnovjbl:
+chelnovjbla:
+0:060048:04:00:00
+0:060080:2C:00:00
+0:0600C0:2C:41:00
+
+;*********nmk16.c (acrobat mission)
+acrobatm:
+0:800ea:8d:00:00
+0:800da:4:00:00
+0:80021:1:48:48
+
+;*********neogeo.c (nightmare in the dark)
+nitd:
+nitdbl:
+0:105da4:3e:00:00
+0:105ddd:1:41:41
+
+;********snk.c (athena) (fix)
+;** fixed, but delete any athena.hi file before playing first time **
+athena:
+0:fe52:6f:41:30
+0:d7f5:3:00:00
+
+;********taito_f3.c (puzzle bobble 2x (japan))
+pbobble2x:
+0:40db78:104:00:3e
+0:40dbd8:1:41:41
+
+;********namcos2.c (phelios (japan))
+phelios:
+pheliosj:
+0:100012:44:00:45
+0:40c478:4:00:50
+0:109373:11:02:01
+
+;********seicross.c (seicross)
+seicross:
+sectrzon:
+0:7ad4:1e:00:0a
+
+;********metro.c (blazing tornado)
+blzntrnd:
+0:ff9338:50:02:00
+0:ff9385:1:10:10
+
+;********nemesis.c (black panther)
+blkpnthr:
+0:90400:99:00:59
+0:90300:4:00:00
+
+;********wecleman.c (wec le mans 24)
+;** only saves top 10 scores (ones you put your name to) **
+wecleman:
+wecleman2:
+weclemana:
+weclemanb:
+0:41110:64:00:20
+0:40006:4:00:00
+
+;********rollerg.c (rollergames (us))
+;** untested - no good at this game !! **
+rollerg:
+rollergj:
+0:2a80:28:08:06
+
+;********flkatck.c (ka)
+mx5000:
+0:3a00:50:00:14
+0:395e:3:00:90
+
+;********flkatck.c
+flkatck:
+flkatcka:
+0:3a00:50:00:14
+0:395e:3:00:90
+
+;********seta.c (mobile suit gundam)
+msgundam:
+msgundam1:
+0:204287:63:01:10
+
+;********toobin.c (toobin` (version 3))
+toobin:
+0:ffff40:32:01:ef
+
+mshvsf:
+mshvsfa1:
+mshvsfb1:
+mshvsfb:
+mshvsfh:
+mshvsfj2:
+mshvsfj1:
+mshvsfj:
+mshvsfu1:
+mshvsfu:
+mshvsfa:
+mshvsfu1d:
+0:ff2b0c:63:00:03
+
+;********taito_b.c (ashura blaster (us))
+ashurau:
+0:6019f9:63:00:19
+0:6012a7:3:00:00
+
+;*********taito_l.c (champion wrestler (world))
+champwr:
+0:89b7:28:00:4e
+
+;*********bladestl.c (blades of steel (version t))
+bladestl:
+bladestle:
+bladestll:
+0:4170:82:23:15
+
+;*********system16.c (atomic point)
+atomicp:
+0:ffd90f:27:01:20
+
+;*********megasys1.c (the astyanax)
+;** top score updates when first game starts **
+astyanax:
+0:f8909:97:00:4e
+0:f885d:f:00:00
+0:f8863:1:02:02
+
+lordofk:
+0:f8921:97:00:4e
+0:f8875:f:00:00
+0:f887b:1:02:02
+
+;*********mrflea.c (the amazing adventures of mr. f. lea)
+;** this game does not display the top score in the top centre of the screen **
+;** untill the game has ran for a while without inserting any credits but this **
+;** does not matter as long as the default 5,000 high score has been beaten on your**
+;** first game.......
+;** which isn`t hard, or you can just let the game run through attract mode for a **
+;** couple of minutes until the 5,000 top score is on screen. it`s up to you !!! **
+mrflea:
+0:cafd:99:30:20
+0:c6f8:6:30:30
+
+;*********system1.c (bullfight)
+bullfgt:
+thetogyu:
+0:d300:3c:00:49
+0:c014:3:00:02
+
+;*********m62.c (spelunker)
+spelunkr:
+spelunkrj:
+0:e052:64:39:3f
+0:e03b:2:39:08
+
+;*********buggychl.c (buggy challenge)
+buggychl:
+buggychlt:
+0:8814:4ec:04:00
+0:80e1:1:04:04
+
+;*********taito_z.c (battle shark (us))
+bshark:
+bsharkj:
+bsharku:
+0:10e9b6:31:00:49
+0:10f0c6:4:00:84
+
+bsharkjjs:
+0:10e9ae:31:00:49
+0:10f0c6:4:00:84
+
+;*********battlera.c (battle rangers (world))
+battlera:
+bldwolf:
+bldwolfj:
+0:1f0220:8a:41:00
+0:1f000e:4:00:00
+0:1f000f:1:10:10
+
+;*********neogeo.c (money puzzle exchanger / money idol exchanger)
+miexchng:
+0:100002:9e:00:0f
+
+;*********seta.c (dragon unit / castle of dragon)
+drgnunit:
+0:ffd50e:50:00:2e
+
+;*********cloak.c (cloak & dagger)
+cloak:
+cloakfr:
+cloakgr:
+cloaksp:
+0:f35:a0:11:58
+
+;***************************************************************
+;* latest :highscore_v7.9 additions below - by leezer*
+;***************************************************************
+
+;*********taito_b.c (rambo 3 us)
+rambo3u:
+rambo3:
+0:802600:50:01:4e
+
+;*********taito_b.c (rambo 3 europe)
+rambo3p:
+0:802600:50:01:2e
+
+;********taito_z.c (aqua jack (world))
+;** game displays highscores wrong (nowt to do with hiscore.dat file,driver issue ??)
+;** top score displays ok..
+aquajack:
+aquajackj:
+0:100160:7c:00:02
+
+;********superchs.c (super chase - criminal termination (us))
+superchs:
+superchsj:
+superchsu:
+0:102815:49:00:47
+
+;********metro.c (bal cube)
+balcube:
+0:f04ac0:4a:00:02
+
+;********alpha68k.c (sky adventure (world & us))
+skyadvnt:
+skyadvntu:
+0:40031:3:00:24
+0:41102:bc:00:20
+
+skyadvntj:
+0:40031:3:00:24
+0:41102:bc:00:49
+
+;********nemesis.c (kitten kaboodle)
+kittenk:
+0:4005a:4:00:00
+0:42800:28:00:10
+
+;********ajax.c (typhoon)
+typhoon:
+0:2100:50:1a:00
+0:2050:4:00:00
+
+;********namcona1.c (tinkle pit (japan))
+tinklpit:
+0:5ca8:174:00:02
+
+;********lassp.c (chameleon)
+chameleo:
+0:4f:4:00:00
+0:120:6e:26:00
+0:50:1:50:50
+
+;********sprint2.c (sprint 1)
+sprint1:
+0:57:3:30:30
+
+chasehq: ;[Special thanks to Cananas for making this entry work, and dnadisturber for adding clones]
+chasehqj:
+chasehqu:
+chasehqju:
+0:101760:a0:20:24
+
+;********spcforce (space force)
+spcforce:
+meteor:
+spcforc2:
+meteors:
+0:4300:50:30:30
+
+;***************************************************************
+;* latest :highscore_v7.8 additions below - by leezer*
+;***************************************************************
+
+;*********senjyo.c (baluba-louk no densetsu)
+baluba:
+0:80f6:4:00:00
+0:80f8:1:03:03
+0:9261:1:8a:8a
+0:9241:1:8a:8a
+0:9221:1:8a:8a
+0:9201:1:83:83
+0:91e1:1:80:80
+0:91c1:1:80:80
+0:91a1:1:80:80
+0:9181:1:80:80
+
+;*********bloodbro.c (sky smasher)
+skysmash:
+0:8925e:50:53:00
+0:80008:4:00:00
+0:80009:1:02:02
+
+;********nyny.c (new york new york)
+nyny:
+nynyg:
+warcadia:
+0:c000:f:00:00
+0:7a7d:1:77:77
+
+;*******m92.c (ninja baseball batman (us))
+nbbatman:
+leaguemn:
+nbbatmanu:
+0:e25d4:4f:00:03
+
+;********volfied.c (volified (japan))
+;** top score on top centre of screen does not update untill  **
+;** after first demo game in attract mode **
+volfied:
+volfiedjo:
+volfiedj:
+volfiedu:
+volfiedo:
+volfieduo:
+0:100200:26:00:50
+0:100201:1:50:50
+
+;********vicduel.c (depthcharge)
+depthch:
+depthcho:
+subhunt:
+0:e408:c:55:5a
+
+arknoid2:  ;** you must let the hiscore table display first before starting a game **
+arknoid2j:
+arknoid2u:
+arknoid2b:
+0:ec81:27:01:4e
+0:e3a8:03:01:00
+
+;*********(block block (world 910910))
+blocka:
+0:e0f0:50:54:85
+
+;*******megasys1.c (saint dragon)
+stdragon:
+stdragona:
+stdragonb:
+0:f8d00:7c:00:d3
+
+;*******sbrkout.c (super breakout(fix))
+sbrkout:
+sbrkout3:
+sbrkoutc:
+sbrkoutct:
+0:22:08:00:00
+
+;*********mcr68.c (pigskin 621ad)
+pigskin:
+0:142a17:157:05:03
+
+pigskina:
+pigskinb:
+0:142b4d:157:05:03
+
+;*********taito_l.c (cuby bop)
+cubybop:
+0:8462:28:05:04
+
+;*********metro.c (bang bang ball (v1.05))
+bangball:
+0:f04b24:9a:46:03
+
+;*********m92.c (gunforce - battle fire engulfed terror island (world))
+gunforce:
+gunforceu:
+0:e6633:40:44:20
+
+gunforcej:
+0:e6633:40:44:4f
+
+;********taito_f2.c (pulirula (world))
+pulirula:
+pulirulaj:
+0:30d586:f9:00:42
+
+;********8080bw.c (space stranger & space stranger 2)
+sstrangr:
+sstrangr2:
+0:20f4:2:00:00
+
+;********sega.c (zektor (revision b))
+zektor:
+0:c924:39:90:10
+0:cfd2:f:0c:02
+
+;*******decocass.c (cassette: astro fantasia)
+castfant:
+0:0b:3:00:00
+0:08:1:3f:3f
+
+;********vsnes.c (battle city)
+btlecity:
+0:3e:6:00:00
+0:3f:1:02:02
+
+;*******cave.c (pretty soldier sailer moon)
+sailormn:
+sailormno:
+sailormnh:
+sailormnj:
+sailormnk:
+sailormnoh:
+sailormnoj:
+sailormnok:
+sailormnot:
+sailormnou:
+sailormnt:
+sailormnu:
+0:10944f:47:02:05
+
+;*******cave.c (mazinger z)
+mazinger:
+mazingerj:
+0:100022:43:00:4e
+
+;******pacman.c (ms pacman (bootleg)
+mspacmab:
+00:4E88:04:00:00
+00:43ED:06:40:40
+00:43D1:01:48:48
+
+;***************************************************************
+;* latest :highscore_v7.7 additions below - by leezer*
+;***************************************************************
+;********fukki16.c (gyakuten!! puzzle bancho (japan)
+pbancho:
+0:402e1f:3b:01:04
+0:400ad3:3:01:a0
+0:400b41:3:05:32
+
+;*********warlord.c (warlord)
+warlords:
+0:f3:9:4d:61
+0:126:2:75:75
+0:12d:2:13:26
+0:13a:2:00:00
+
+;********travusa.c (fix)
+travrusa:
+motorace:
+mototour:
+travrusab:
+0:e07c:4b:00:15
+0:e008:3:00:03
+
+;********pacman.c (ponpoko)
+ponpoko:
+ponpokov:
+candory:
+0:4c40:3:00:00
+0:4e5a:13:00:00
+0:406c:6:0f:00
+0:4c53:1:02:02
+
+;********taito_f3.c (gekirindan (japan))
+gekiridnj:
+gekiridn:
+0:408e72:7a:00:01
+0:408e4c:4:00:00
+
+;********starfire.c (star fire)
+starfire:
+0:82ba:a5:00:00
+
+wotw: ;[Special thanks to Cananas for enhancing this entry]
+wotwc:
+0:01f0:04:00:00
+0:012a:06:00:1e
+
+;********vsnes.c (vs. wrecking crew)
+wrecking:
+0:a1:3:00:00
+0:6000:1e:06:16
+
+;********unico16.c (zero point)
+zeropnt:
+zeropntj:
+zeropnta:
+0:ef1eb4:24:00:10
+0:ef1f58:23:55:53
+
+;********undrfire.c (under fire (world))
+undrfire:
+0:20dfaf:75:08:53
+
+;********decocass.c (cassette: pro tennis & world tennis)
+cptennis:
+wtennis:
+0:db:3:00:00
+0:b2:1:da:da
+
+;*******munchmo.c (joyful road / munch mobile)
+joyfulr:
+mnchmobl:
+0:813a:3:00:00
+0:8313:6b:30:4b
+0:813b:1:10:10
+
+;*******metro.c (dharma doujou)
+dharma:
+dharmak:
+dharmaj:
+0:40e302:4b:00:5a
+
+;***************************************************************
+;* latest :highscore_v7.6 additions below - by leezer*
+;***************************************************************
+
+;********shanghai.c (shanghai ii (japan))
+shangha2:
+shangha2a:
+0:180b:be:90:01
+
+;********shanghai.c (shanghai (japan))
+shanghaij:
+shanghai:
+0:201b:b4:90:1e
+
+;*********taito_l.c (cachat (japan))
+cachat:
+0:8d0d:4c:4b:00
+0:8d57:1:10:10
+
+;*********dec0.c (boulder dash/boulder dash part 2 (world))
+; ** top score updates at start of first game **
+bouldash:
+0:306d4d:44:00:52
+0:306aa1:3:00:00
+
+;*********gaelco.c (biomechanical toy (unprotected))
+;** you must let the highscore display in attract mode before starting a game  ** 
+biomtoy:
+biomtoya:
+0:ff0794:17:06:2e
+
+;*********marvins.c (marvins maze)
+marvins:
+0:c290:46:00:4b
+0:c28b:4:00:00
+0:c28c:1:01:01
+
+;*********outrun.c (super hang-on (bootleg))
+shangonb:
+shangonrb:
+shangonro:
+0:20d400:1b2:01:00
+0:20d5ad:1:20:20
+0:20d678:70:99:99
+
+;********namcos2.c (dragon saber)
+dsaber:
+dsabera:
+0:108080:8c:ce:60
+0:10819e:40:00:00
+0:1081d9:1:70:70
+
+dsaberj:
+0:108080:8c:ce:95
+0:10819e:40:00:00
+0:1081d9:1:70:70
+
+;********higemaru (pirate ship higemaru)
+higemaru:
+0:ee00:82:00:4f
+0:ee97:3:00:00
+0:d04e:7:20:30
+
+;********baraduke.c (baraduke)
+baraduke:
+aliensec:
+0:280:49:00:20
+0:74:3:00:65
+
+;********seta.c (extreme downhill v1.5)
+extdwnhl:
+0:20286c:2c4:4d:40
+
+;*******atarisys1.c (indiana jones and the temple of doom (set 1&4))
+indytemp:
+indytemp4:
+indytempd:
+indytemp2:
+0:401e56:32:01:16
+0:400fbe:32:01:16
+
+indytemp3:
+0:401e56:32:01:16
+0:401152:32:01:16
+
+;*******tunhunt.c (tunnel hunt)
+tunhunt:
+tunhuntc:
+0:300:20:00:44
+0:b0:1:03:03
+
+;*******mhavoc.c (major havoc (rev 3))
+mhavoc:
+0:184:46:0b:00
+0:95:1:02:02
+
+;*******segac2.c (zunzunkyou no yabou (japan))
+zunkyou:
+0:fffa01:4f:00:01
+
+;***************************************************************
+;* latest :highscore_v7.5 additions below - by leezer*
+;***************************************************************
+
+;********blmbycar.c (blomby car)
+;** highscore only saves , other course highscores are not possible **
+;** as they don`t load in until you finish a course **
+blmbycar:
+blmbycaru:
+0:fecdbc:117:4e:08
+
+;********williams.c (mayday (set 1))
+mayday:
+maydaya:
+maydayb:
+batlzone:
+0:b260:3c:00:55
+
+;********namconb1.c (nebulas ray (japan))
+nebulray:
+nebulrayj:
+0:22a769:8a:22:4c
+0:23be6a:4:00:a0
+
+;********metro.c (lady killer)
+ladykill:
+moegonta:
+0:ffe20f:67:00:8c
+
+;********exzisus.c (exzisus (japan))
+exzisus:
+exzisusa:
+exzisust:
+0:f840:3c:00:4f
+;0:c9c6:1:20:20
+;0:c9ca:1:20:20
+;0:c9ce:1:05:05
+;0:c9d2:1:02:02
+;0:c9d6:1:02:02
+;0:c9da:1:05:05
+
+;********segasyse.c (transformer)
+;** saves top 10 scores displayed in attract mode **
+transfrm:
+astrofl:
+0:f900:37:00:4b
+0:c080:4:00:00
+
+;*******namconb1.c (gun bullet (japan))
+gunbuletj:
+0:21ccd4:68:00:01
+
+;*******segasyse.c (hang-on jr.)
+hangonjr:
+0:d000:69:02:2c
+0:c07d:3:02:00
+
+;*******segasyse.c (riddle of the pyphagoras (japan))
+ridleofp:
+0:e215:c8:00:4e
+
+;*******chinagat.c (china gate (us))
+chinagat:
+saiyugoub1:
+saiyugoub2:
+saiyugou:
+0:c83:23:00:21
+
+;********unico16.c (burglar x)
+burglarx:
+0:ff2524:5a:01:01
+0:ffce7c:4:01:00
+
+;*******vsnes.c (hogans alley)
+hogalley:
+0:4a0:19:12:2f
+0:4be:2:12:28
+
+;*******scobra.c (calipso)
+calipso:
+0:81cb:3c:01:45
+
+;********foodf.c (food fight)
+foodf:
+foodfc:
+foodf2:
+foodf1:
+0:17ba8:2d:4a:45
+0:17f64:3c:00:2f
+0:1860e:7:35:a5
+
+;*******namcona1.c (emeraldia (japan))
+emeralda:
+0:9c9e:10e:4b:01
+
+;*******neogeo.c (pulstar)
+pulstar:
+0:100000:2c:00:58
+
+;*******neogeo.c (pop `n bounce)
+popbounc:
+0:100004:648:00:01
+
+;********metro.c (poitto!)
+poitto:
+0:40e31a:4e:00:41
+0:40e2ec:4:00:00
+0:40e2ed:1:02:02
+
+;********cheekyms.c (cheeky mouse)
+cheekyms:
+0:3009:9:00:00
+0:3014:1:36:36
+
+;********cinemat.c (solar quest)
+solarq:
+0:e0:50:08:00
+
+;********megasys1.c (soldam (japan))
+;** you must let the game display the highscore in attract mode before **
+;** starting a game - just like in star force                          **
+soldamj:
+soldam:
+0:1f00ba:8:00:00
+0:1f3fbe:24a:00:81
+
+;********gundealr.c (yam! yam!?)
+yamyam:
+wiseguy:
+yamyamk:
+0:eba8:3f:00:4d
+
+;*******metro.c (pang pomms)
+pangpoms:
+0:c0de63:77:10:01
+
+pangpomsm:
+0:c0de63:77:10:01
+
+;********taito_f3.c (puzzle bobble 4 (world))
+pbobble4:
+0:40e85a:116:00:00
+0:40e8ba:1:41:41
+
+;********fuuki16.c (go go! mile smile)
+gogomile:
+0:40660d:161:01:14
+0:4066CF:1:05:05
+
+;********namcos1.c (marchen maze (japan))
+mmaze:
+0:12c1:3:00:00
+0:1241:27:00:01
+0:1100:1:95:95
+
+;*******argus.c (butasan (japan))
+butasanj:
+butasan:
+0:fab0:110:00:07
+0:fca0:5:00:00
+0:fca2:1:02:02
+
+;******namcos1.c (puzzle club (japan prototype))
+puzlclub:
+0:24fc:7c:0f:2e
+0:263f:bf:0d:45
+
+;*******neogeo.c (shock troopers)
+shocktro:
+0:10ef04:27:00:08
+
+;*******toaplan2.c (teki paki)
+tekipaki:
+0:80013:3f:00:60
+
+;*******dcon.c (d-con)
+dcon:
+0:83138:64:53:10
+
+;*******jack.c (brix / zzyzzyxx set 1&2)
+brix:
+zzyzzyxx:
+zzyzzyxx2:
+0:5100:28:00:00
+0:5400:1e:9d:a3
+0:5126:1:50:50
+
+;*******shootout.c (shoot out (us))
+shootout:
+0:24a:4e:44:60
+0:53:3:05:00
+0:54:1:80:80
+
+shootoutj:
+shootoutb:
+0:24a:4e:44:60
+0:5f:3:05:00
+0:60:1:80:80
+
+;*******pandoras.c (pandoras palace)
+pandoras:
+0:6100:2d:18:20
+0:60d0:4:00:50
+
+;********pacman.c (dream shopper)
+dremshpr:
+0:4c00:f0:00:01
+0:4808:6:00:00
+0:4809:1:03:03
+
+;********neogeo.c (nam-1975)
+nam1975:
+0:100040:4f:00:4b
+
+;********taito_f2.c (thunder fox (japan))
+thundfox:
+thundfoxj:
+thundfoxu:
+0:303b2c:32:00:49
+0:303c56:4:00:00
+0:303b59:1:01:01
+
+;********champbas.c (champion baseball (fix))
+champbas:
+0:8c30:2f:40:00
+0:8c5c:1:05:05
+
+;********cave.c (dangun feveron (japan))
+dfeveron:
+feversos:
+0:103eb4:16d:02:07
+
+;********cave.c (guwange (japan))
+guwange:
+0:2024f0:140:00:10
+0:2024ac:4:00:00
+
+guwanges:
+0:2024fa:140:0:10
+0:2024b6:4:00:00
+
+;********namcos1.c (blazer (japan))
+blazer:
+0:30ad:5f:00:20
+0:2888:8:00:00
+0:288b:1:03:03
+
+;*******neogeo.c (aero fighters 3/sonic wings 3)
+sonicwi3:
+0:10000c:cf:4b:20
+
+;********neogeo.c (aero fighters 2/sonic wings 2)
+sonicwi2:
+0:10000e:52:48:03
+
+;*******dec0.c (midnight resistance (world & us))
+midres:
+midresu:
+midresb:
+midresbj:
+0:1026ea:50:00:26
+0:102710:1:78:78
+
+midresj:
+0:1026ec:50:00:26
+0:102712:1:78:78
+
+;********vsnes.c (the goonies)
+goonies:
+0:7f0:3:00:01
+
+;********alpha68k.c (time soldiers (us rev 3))
+;** ignore first highscore screen, updates on next highscore show !! **
+timesold:
+timesold1:
+0:204101:bf:00:0c
+0:40030:4:00:00
+0:4003c:1:02:02
+0:4003d:1:09:09
+
+;******Battle Field (bootleg)
+btlfieldb:
+btlfield:
+0:40030:4:00:70
+0:204101:bf:00:0c
+
+;********vsnes.c (clu clu land)
+cluclu:
+0:751:4f:1d:70
+0:19:3:05:20
+
+;********aerofgt.c (turbo force)
+turbofrc:
+0:c221b:4e:04:54
+
+;*******taito_f3.c (twin qix(us prototype)
+twinqix:
+0:406b6f:9b:00:54
+
+;***************************************************************
+;* latest :highscore_v7.4 additions below - by leezer*
+;***************************************************************
+
+;********momoko.c (momoko 120%)
+momoko:
+0:ce01:9f:20:20
+0:c049:7:20:30
+
+;*******yunsun16.c (magic bubble)
+magicbub:
+0:ff3c66:4e:00:20
+
+magicbuba:
+magicbubb:
+0:ffc127:4d:07:20
+
+;******zaxxon.c (ixion (prototype))
+ixion:
+0:610d:1e:00:00
+0:61d2:1e:23:24
+
+;********taito_f3.c (elevator action returns (world))
+elvactr:
+0:40ce3a:7c:00:01
+0:40ce3c:1:c3:c3
+
+;********scregg.c (dommy)
+dommy:
+0:1a:3:00:05
+
+;********omegaf.c (omega fighter / omega fighter special)
+;** only saves pasrt of highscore ?? - tables ok though !! **
+omegaf:
+omegafs:
+0:f880:7f:00:24
+0:f7d4:3:00:00
+0:f7d5:1:20:20
+
+;*******taito_f3.c (darius gaiden - silver hawk / extra version )
+dariusg:
+dariusgx:
+dariusgu:
+dariusgj:
+0:406cd4:39:00:59
+
+;*******taito_b.c (silent dragon (world))
+silentd:
+silentdj:
+silentdu:
+0:403E03:65:01:20
+
+;********megasys1.c (hachoo)
+hachoo:
+0:f0072:100:00:59
+0:f017e:4:00:00
+0:f0073:1:05:05
+
+;*******snk68.c (street smart (us version 1)) / (us version 2)
+streetsm1:
+streetsm:
+streetsmj:
+streetsmw:
+0:41470:a0:20:20
+0:43f7e:4:00:00
+
+;*******namcos2.c (finest hour (japan))
+finehour:
+0:106afe:64:00:5a
+0:10002a:4:00:00
+
+;*******gameplan.c (killer comet)
+killcom:
+0:88:2:47:00
+
+;*******twin16.c (devil world)
+devilw:
+majuu:
+0:60131:ef:00:10
+0:60049:3:00:30
+
+darkadv:
+0:60131:ef:00:10
+
+;*******suna16.c (ultra balloon)
+uballoon:
+0:80048c:4f:00:45
+
+;*******megasys1.c (takeda shingen (japan))
+tshingen:
+tshingena:
+0:f0f00:3a:00:4e
+
+;*******seta.c (strike gunner s.t.g.)
+stg:
+0:ffda3e:28:42:00
+0:ffda64:1:31:31
+
+;*****(f-1 dream)
+f1dream:
+f1dreamb:
+0:fff132:60:59:01
+0:fff2e9:5f:01:34
+
+;******atarisy1.c (road runner)
+roadrunn:
+0:401e42:32:00:da
+
+;added galaxiaj (galaxian (namco set 2))
+
+;***************************************************************
+;* latest :highscore_v7.3 additions below - by leezer*
+;***************************************************************
+
+;*******taito_b.c (ryu jin (japan))
+ryujin:
+0:103e3c:63:54:01
+0:103f20:4:00:00
+
+;*******xxmissio (xx mission)
+xxmissio:
+0:e018:4:00:00
+0:e084:61:20:20
+0:c1a0:1:30:30
+0:c1c0:1:30:30
+0:c1e0:1:30:30
+0:c200:1:30:30
+0:c220:1:33:33
+0:c240:1:01:01
+0:c260:1:01:01
+
+;*******karnov.c (wonder planet (japan))
+wndrplnt:
+0:60048:ac:00:01
+0:600dd:1:4d:4d
+
+;********metro.c (mouja (japan))
+mouja:
+0:f00064:12c:00:37
+
+;********shangkid.c (shanghai kid (japan))
+shangkid:
+hiryuken:
+0:e128:50:00:17
+
+;********bjtwin (thunder dragon 2)
+tdragon2:
+0:1ff101:6b:18:00
+
+;*******big bang
+bigbang:
+tdragon2a:
+0:1ff101:6b:18:00
+0:1ff169:1:01:01
+
+;********suna8.c (rough rangers(v2.0 sharp image licence))
+rrangerb:
+0:d220:4c:00:20
+0:c851:2:00:03
+
+;********parodius.c (parodius da! (japan))
+parodius:
+parodiusj: 
+parodiusa:
+parodiuse:
+0:1f50:5e:00:00
+0:1f51:1:05:05
+
+;********neogeo.c (zed blade)
+zedblade:
+0:108f00:50:00:11
+
+;********neogeo.c (cyber-lip)
+cyberlip:
+0:100000:50:00:20
+
+;********dooyong.c (r-shark)
+rshark:
+0:340382:4e:4e:41
+
+;*******prehisle.c (prehistoric isle in 1930 (world))
+prehisle:
+gensitou:
+prehisleu:
+prehislek:
+0:700a0:4e:00:00
+0:7003d:5:00:00
+0:700ec:1:01:01
+
+;*******sbasketb.c (super basketball)(fix)
+sbasketb:
+0:2a26:194:ef:14
+0:20ac:3:00:00
+0:3521:1:10:10
+0:3501:1:10:10
+0:34e1:1:10:10
+0:34c1:1:10:10
+0:34a1:1:10:10
+0:3481:1:00:00
+0:3461:1:00:00
+
+;***************************************************************
+;* latest :highscore_v7.2 additions below - by leezer*
+;***************************************************************
+
+;********chqflag.c (chequered flag)
+chqflag:
+0:1f08:dd:30:42
+
+;********taito_f3.c (puzzle bobble 3 (world))
+pbobble3:
+0:41eff0:99:00:04
+
+;********sgladiat.c (gladiator 1984)
+sgladiat:
+0:d9b0:28:00:4b
+
+;********cave.c (hotdog storm)
+hotdogst:
+0:301100:54:00:14
+
+;********bjtwin.c (bio-ship paladin)
+bioship:
+sbsgomo:
+0:f0150:8:00:00
+0:f0169:a3:00:00
+0:f0207:1:4c:4c
+
+;********decocass.c (cassette: boulder dash)
+cbdash:
+0:200:8c:01:13
+0:23:3:88:01
+
+;*********tetrisp2.c (tetris plus 2(JAPAN))
+teplus2j:
+tetrisp2:
+tetrisp2ja:
+0:10dfb7:b3:01:00
+0:10e065:1:01:01
+0:10b0f2:460:03:09
+
+;*********cninja.c (robocop 2)
+robocop2:
+robocop2j:
+robocop2u:
+robocop2ua:
+0:1b8300:27:4e:21
+0:1b8200:28:00:00
+0:1b8020:4:00:00
+
+;*********neogeo.c (puzzle bobble2/bust a move again)
+pbobbl2n:
+0:10ee00:112:00:d4
+0:10fe8b:1:23:23
+
+;********shocking.c (shocking)
+shocking:
+shockingk:
+shockingko:
+0:ff0d19:63:41:64
+
+;********marineb.c (battle cruiser m12)
+bcruzm12:
+0:858c:45:00:12
+
+;********nemesis.c (twinbee)
+twinbee:
+0:1f580:58:00:0a
+0:1eba0:4:00:00
+
+;********skydiver.c (sky diver)
+;** note highscore must be displaying new top score to save properly **
+;** so start a new game after a new highscore and kill man 3 times **
+;** untill new highscore is displayed. **
+skydiver:
+0:af:3:00:00
+
+;********magix.c (cannon ball)
+cannball:
+cannballv:
+0:f800:80:00:2e
+
+;***************************************************************
+;* latest :highscore_v7.1 additions below - by leezer*
+;***************************************************************
+
+;********vsnes.c (platoon)
+platoon:
+0:700:e9:10:60
+
+;********vsnes.c (super skykid)
+vsskykid:
+0:10:6:00:00
+0:26:6:00:3f
+
+;*******bosco.c (bosconian)
+; ** highscore beaten at 20,000 every time **
+; ** no way around this **
+; ** highscore table ok though !! :0)      **
+boscomd:
+bosco:
+boscomdo:
+boscoo:
+boscoo2:
+0:8bc5:f:17:18
+0:8be4:10:00:00
+0:885c:4:00:00
+0:8060:8:00:02
+
+;********gameplan.c (challenger)
+challeng:
+0:cc:f:00:1f
+
+;********m92.c (lethal thunder)
+lethalth:
+thndblst:
+0:e0086:b7:00:08
+
+;********taito_f3.c (arabian magic)
+arabianm:
+arabianmj:
+arabianmu:
+0:410ef8:30:00:01
+
+;********vsnes.c (duck hunt)
+duckhunt:
+0:640:20:12:28
+
+;********vsnes.c (dr mario)
+drmario:
+0:120:9b:00:15
+
+;********vsnes.c (vs super mario bros)
+suprmrio:
+0:6675:8b:05:00
+0:7d7:6:00:00
+
+suprmrioa:  ;******Vs. Super Mario Bros. (alt)
+0:6675:8b:05:00
+0:7d7:6:00:00
+
+;********leland.c (danger zone)
+dangerz:
+1:e908:12e:52:14
+
+;********sega.c (eliminator)
+elim2:
+0:c924:14:00:00
+0:c99f:1e:0c:03
+
+elim2a:
+0:c924:14:25:05
+0:c99f:1e:0c:03
+
+elim4:
+0:cc4d:1e:0c:03
+0:c928:14:00:00
+
+;********zodiak.c (dog fight)
+dogfight:
+0:587e:82:20:ff
+0:b2df:1:24:24
+0:b2ff:1:24:24
+0:b31f:1:03:03
+0:b33f:1:05:05
+0:b35f:1:02:02
+0:b37f:1:00:00
+0:b39f:1:00:00
+
+;*******playch10.c (playchoice 10 - balloon fight)
+;pc_bfght:
+;1:629:5:00:00
+;1:d:5:00:00
+
+;*******playch10.c (playchoice 10 - 1942)
+;pc_1942:
+;1:7bf:6:00:00
+
+;*******lwings.c (section z)
+sectionz:
+sectionza:
+0:ce00:51:00:00
+0:ce97:3:00:00
+0:ce4f:1:08:08
+
+;********tmnt.c (thunder cross 2)
+thndrx2:
+thndrx2a:
+thndrx2j:
+0:1002f0:50:00:40
+
+;*********alpha68k.c (sky soldiers)
+skysoldr:
+skysoldrbl:
+0:204100:c0:00:0c
+0:40030:4:00:00
+
+;*******cave.c (donpachi)
+donpachi:
+donpachj:
+donpachihk:
+donpachikr:
+0:101782:4:00:00
+0:101846:5a:00:01
+
+;********cave.c
+ddonpach:
+ddonpachj:
+ddonpacha:
+0:1016ea:64:00:05
+0:101626:4:00:06
+
+;********quantum.c (quantum)
+;* signiture is screwed up (other scores ok) *
+quantum:
+quantum1:
+quantump:
+0:1b5aa:1254:00:54
+
+;******playch10.c (play choice 10:super mario bros)
+;pc_smb:
+;1:7d7:7:00:00
+
+;*******playch10.c (play choice 10:rc pro am)
+;pc_rcpam:
+;1:378:64:17:29 
+
+;********deniam.c (karian cross)
+karianx:
+0:ff069c:68:4b:30
+
+;*********cclimber.c (swimmer)
+swimmer:
+swimmera:
+swimmerb:
+0:84e0:2d:00:48
+0:8577:6:00:00
+
+;******cvs.c (heart attack)
+heartatk:
+0:3c00:27:01:1b
+
+;********cvs.c (logger)
+logger:
+0:3c09:30:00:00
+
+;******cvs.c (dazzler)
+;** udates highscore at end of 1st game **
+;** or after 2nd attract mode **
+dazzler:
+0:3cea:20:00:1b
+0:3d11:2b:00:00
+
+;*******cvs.c (video 8 ball)
+8ball:
+8ball1:
+0:3c0c:38:00:00
+
+;*******suprloco.c (super locomotive)
+;*******saves top 10 scores only
+;*****can`t be bothered with lower scores !!
+suprloco:
+suprlocoa:
+suprlocoo:
+0:fd00:1e:02:00
+0:fca0:12:41:48
+0:fc2c:3:02:00
+
+;*********** latest unofficial additions above this line **************
+;*******************************************************************
+;********* official hiscore.dat v7.0 starts here *******************
+
+;********1943.c
+1943u:
+1943:
+1943ua:
+0:e600:60:00:00
+0:e110:8:00:00
+0:d1be:1:24:24
+0:d1de:1:24:24
+0:d1fe:1:02:02
+0:d21e:1:00:00
+0:d23e:1:00:00
+0:d25e:1:00:00
+0:d27e:1:00:00
+
+1943kai:
+1943j:
+1943b:
+1943ja:
+1943bj:
+0:e600:60:00:00
+0:e110:8:00:00
+0:d1be:1:24:24
+0:d1de:1:02:02
+0:d1fe:1:00:00
+0:d21e:1:00:00
+0:d23e:1:00:00
+0:d25e:1:00:00
+0:d27e:1:00:00
+
+;********8080bw.c
+280zzzap:
+0:203d:2:00:00
+0:2029:4:00:00
+
+ballbomb:
+0:20dc:03:00:00
+
+blueshrk:
+0:200a:05:00:00
+
+bowler:
+0:22a0:08:00:00
+
+clowns:  ;*** dont start game untill attract mode starts.(hiscore also updated then)
+clowns1:  ;*** dont start game untill attract mode starts.(hiscore also updated then)
+0:2015:02:00:00
+0:3ea0:140:00:66
+
+desertgu:
+0:2006:02:00:00
+0:200b:02:00:00
+
+galxwars:
+starw:
+galxwarst:
+galxwars2:
+starw1:
+0:2005:06:00:00
+
+; updated when start a game
+helifire:
+helifirea:
+0:6008:3:00:00
+
+invadpt2:
+invaddlx: 
+0:20f4:2:00:05
+0:2340:a:1b:1b
+
+moonbase:
+moonbasea:
+0:2340:a:0d:14
+0:20f4:2:00:05
+
+invrvnge:
+invrvngea:
+invrvngeb:
+invrvngedu:
+invrvngegw:
+0:2019:3:00:00
+
+lagunar:
+0:2011:9:00:00
+0:2005:3:00:00
+
+lrescue:
+warl:
+desterth:
+lrescuem:  
+lrescuem2:
+;updated when start a game
+0:20db:1:0a:0a
+0:20cf:a:1b:1b
+0:20f4:2:00:05
+
+lupin3:
+0:20dc:03:00:00
+
+ozmawars:
+ozmawars2:
+solfight:
+spaceph:
+0:2043:02:00:00
+
+polaris:
+0:2314:02:00:00
+
+polarisa:
+polarisbr:
+0:2150:14:00:00  
+0:2165:1e:2a:2a 
+0:2314:02:00:00 
+
+rollingc:
+0:2302:0f:00:00
+
+schaser:
+schasera:
+schaserb:
+schaserc:
+0:2244:0a:1b:1b
+0:233f:03:01:00
+
+schasercv:
+0:233d:03:01:00
+
+seawolf: ;[Special thanks to Cananas for enhancing this entry]
+0:2006:01:00:00
+0:2001:01:09:09
+
+spcenctr:
+0:26f0:2:0e:0e
+0:202e:2:00:00
+0:202b:2:00:00
+
+;********actfancr.c 
+actfancr:
+actfancrj:
+actfancr1:
+0:1f0ce6:1e:05:45
+0:1f00be:3:00:00
+
+;********aerofgt.c
+aerofgt:
+0:ffc1af:97:0b:64
+
+;********ajax.c
+ajax:
+ajaxj:
+0:2100:50:1a:00
+0:2050:4:00:00
+
+turtles:
+turpin:
+turpins:
+600:
+0:8200:1e:00:00
+0:80a8:3:00:00
+0:9340:1:01:01
+
+;********appoooh.c
+appoooh:
+0:e029:3:53:4d
+0:e017:6:00:00
+0:e018:1:01:01
+0:e400:dc:53:00
+
+;********argus.c
+argus:
+0:fb80:40:00:00
+0:e039:7:00:00
+0:e03d:1:07:07
+
+valtric:
+0:fca0:28:00:53
+0:fc38:4:00:00
+
+arkanoid: ;[Special thanks to Cananas for enhancing this entry]
+ark1ball: 
+arkangc: 
+arkangc2: 
+arkbloc2:
+arkblock:
+arkgcbl: 
+arkmcubl:
+arkanoidu:
+arkanoiduo:
+arkatayt:
+paddle2:
+arkgcbla:
+arkbloc3:
+arkanoidjo:
+arkanoidjb:
+arkanoidja:
+arkanoidjb:
+arkanoidjbl:
+arkanoidjb2:
+arkanoidjbl2:
+arkanoidj:
+0:ef79:23:00:52
+0:c4df:03:00:00
+
+block2:
+0:ef79:23:00:4a
+0:c4df:03:00:00
+
+arktayt2:
+0:ef79:23:00:42
+0:c4df:03:00:00
+
+arkatour:
+0:ef7c:23:00:52
+0:c4df:03:00:00
+
+;********armedf.c
+armedf:
+armedff:
+0:611b6:4f:00:4a
+0:61206:4:00:00
+
+cclimbr2:
+0:612a7:49:10:00
+0:612f2:1:50:50
+
+terraf:
+terrafu:
+terrafa:
+terrafb:
+terrafjb:
+terrafj:
+0:6066e:3c:00:4a
+0:606b2:4:00:00
+
+asteroi1:
+0:001c:35:00:00
+
+;********astrocde.c
+gorf: ;* resetting screws up 2 scores and top score
+gorfpgm1:
+0:d010:22:00:00
+
+robby:
+0:e1c7:21:4a:4b
+0:e161:1e:50:58
+0:e19d:2a:9e:47
+0:e13b:26:10:17
+0:e3c7:21:4a:4b
+0:e361:1e:50:58
+0:e39d:2a:9e:47
+0:e33b:26:10:17
+
+seawolf2:;*loading score seems to auto start a game?
+0:c208:2:00:00
+
+wow: ;*resetting screws up the 1st score
+wowg:
+0:d004:14:00:00
+0:d304:14:00:00
+
+tomahawk:
+tomahawk1:
+0:000d:2:00:00
+0:4251:25:3c:3c
+
+;********asuka.c
+asuka:
+asukaj:
+0:103458:66:41:01
+0:1033c4:4:00:20
+
+galmedes:
+0:1031a0:4c:00:64
+
+mofflott:
+0:100aad:75:00:31
+
+;********atarisy2.c
+apb:
+apb5:
+apb6:
+0:f42:9b:00:4d
+
+apb2:
+apbf:
+apbg:
+apb1:
+apb3:
+apb4:
+0:f42:9b:00:50
+
+;********badlands.c
+badlands:
+0:fffe96:4f:00:9a
+
+pickin:
+0:719a:50:00:10
+
+;********bankp.c
+bankp:
+0:e590:a0:00:00
+0:e018:7:00:00
+
+;********batman.c
+batman:
+0:10f23e:50:00:35
+
+;********battlane.c
+battlane:
+battlane2:
+battlane3:
+0:0ca5:28:00:1a
+0:005f:3:00:00
+
+frenzy:
+0:406e:3c:00:00
+0:405e:1:ff:ff
+
+;********bionicc.c
+bionicc:
+bionicc2:
+topsecrt:
+bionicc1:
+bioniccbl:
+0:fff9e2:4f:00:4d
+0:ffc57a:4:00:00
+0:fec0d9:1:20:20
+0:fec0db:1:20:20
+0:fec0dd:1:20:20
+0:fec0df:1:02:02
+0:fec0e1:1:00:00
+0:fec0e3:1:00:00
+0:fec0e5:1:00:00
+0:fec0e7:1:00:00
+
+;macross:  *** not working ***
+;0:f9100:a0:00:45
+;0:f90f6:1:01:01
+
+blkdrgon:
+blkdrgnb:
+0:e200:50:00:26
+0:e1e0:8:00:00
+
+;********blockout.c
+blockout:
+0:1d5fa4:78:32:05
+0:1d5ece:4:00:00
+
+blockout2:
+blockoutj:
+0:1d5fa2:78:32:05
+0:1d5ece:4:00:00
+
+;********blstroid.c
+blstroid:
+blstroid2:
+blstroidh:
+blstroidg:
+blstroid3:
+0:ffff42:32:06:16
+
+
+;********blueprnt.c
+blueprnt:
+blueprntj:
+0:8100:3e:00:90
+
+saturnzi:
+0:8380:28:00:2d
+
+;********bombjack.c
+bombjack:
+bombjack2:
+bombjackt:
+0:905f:1:30:30
+0:907f:1:30:30
+0:909f:1:30:30
+0:90bf:1:30:30
+0:90de:3:53:24
+0:90fe:3:2d:24
+0:911f:1:00:00
+0:913f:1:00:00
+0:80e2:4:00:00
+0:8100:96:00:ff
+
+darwin:
+0:1b93:9:8b:89
+0:1b6c:10:00:70
+
+btime:
+btime2:
+btimem:
+btime3:
+0:0033:27:00:FF
+
+cookrace:
+0:0032:24:00:18
+
+ringking3:
+1:8048:8C:00:12
+0:C234:04:00:05
+
+lnc:
+0:0008:3:00:00
+0:0294:f:00:00
+0:02a6:f:00:00
+0:3C4D:6:00:01
+
+mmonkey:
+0:df:f:00:00
+0:32:3:00:02
+0:310:f:2e:2f
+0:3c4a:6:00:01
+
+zoar:
+0:02dd:3:00:00
+0:02e5:f:00:00
+0:034b:3:20:20
+0:0356:3:20:20
+0:0361:3:20:20
+0:036c:3:20:20
+0:0377:3:20:20
+
+spacduel:
+spacduel0:
+spacduel1:
+0:dd:3c:00:00
+0:119:4b:00:1c
+
+;********bzone.c
+bzone:
+bzonea:
+bzone2:
+bzonec:
+0:0300:3c:05:38
+
+;*note top score updates after a few seconds
+redbaron:
+redbarona:
+0:155:23:0:0
+0:178:1:d4:d4
+
+;********cadash.c
+cadash:
+cadashu:
+cadashi:
+cadashf:
+cadashg:
+0:103646:185:00:4d
+
+cadashj:
+cadashj1:
+cadashjo:
+0:103646:18a:00:65
+
+;********canyon.c
+canyon:
+canyonp:
+0:0037:4:00:00
+
+uopoko:
+uopokoj:
+0:100038:6e:00:20
+
+;********cchasm.c
+cchasm:
+cchasm1:
+0:fff4b8:78:72:10
+
+cclimber: ;[Special thanks to Cananas for enhancing this entry]
+cclimberj:
+ccboot:
+cclimbroper:
+cclimbrrod:
+0:8083:03:02:00
+0:8095:0a:30:52
+0:8086:03:02:00
+0:80a3:0a:30:52
+0:8089:03:02:00
+0:80b1:0a:30:52
+0:808c:03:02:00
+0:80bf:0a:30:52
+0:808f:03:02:00
+0:80cd:0a:30:52
+
+ccboot2:
+0:8083:03:02:00
+0:8095:0a:15:52
+0:8086:03:02:00
+0:80a3:0a:15:52
+0:8089:03:02:00
+0:80b1:0a:15:52
+0:808c:03:02:00
+0:80bf:0a:15:52
+0:808f:03:02:00
+0:80cd:0a:15:52
+
+;********cinemat.c
+armora:
+armorap:
+armorar:
+0:a2:4:00:00
+
+;starcas:
+;starcas1:
+;starcase:
+;starcasp: 
+;stellcas: 
+;0:1aa:4:00:00
+
+crash:
+smash:
+0:000f:2:00:00
+
+;********cischeat.c (cisco heat)
+cischeat:
+0:f0c00:24f:00:00
+0:f0e42:1:49:49
+0:f0b00:28:00:00
+
+f1gpstar:
+0:f2803:5e3:04:4d
+
+;********citycon.c
+citycon:
+citycona: 
+cruisin:
+0:0055:3:00:13
+0:0043:3:00:02
+0:0900:f0:53:90
+
+;******cninja.c
+cninja:
+cninjau:
+joemac:
+0:1877fb:1:30:30
+0:1877fa:ae:00:00
+
+cninja1:
+stoneage:
+cninjabl:
+cninjaa:
+0:1877f7:1:30:30
+0:1877f6:ae:00:00
+
+;********combatsc.c
+combatsc:
+combatscb:
+combatscj:
+combatsct:
+0:1320:46:02:07
+0:826:3:00:10
+
+;********commando.c
+commando:
+commandou:
+commandoj:
+sinvasn:
+sinvasnb:
+commandob:
+commandob2:
+commandou2:
+mercenario:
+0:ee00:5b:00:2e
+0:ee97:3:00:00
+
+;********congo.c
+congo:
+tiptop:
+congoa:
+0:8020:7e:90:a1
+0:80bd:3:00:00
+
+;********contra.c
+contra:
+contrab:
+contraj:
+contrajb:
+gryzor:
+contrabj1:
+gryzor1:
+gryzora:
+contra1:
+contrabj:
+contraj1:
+contrae:
+0:1120:40:1b:00
+0:1118:4:00:00
+
+;********cop01.c
+cop01:
+0:c46d:28:00:01
+
+cop01a:
+0:c46e:28:00:01
+
+;********cosmic.c
+cosmica:
+cosmica2:
+cosmica1:
+0:400e:3:00:00  
+
+panic:
+panich:
+panicger:
+panic2:
+panic3:
+0:40c1:5:00:00
+0:5c00:c:09:15
+0:4004:2:00:00   
+
+;********cps1.c
+1941:
+1941j:
+1941u:
+1941r:
+1941r1:
+0:ff9680:78:ff:00
+0:ff0d98:04:00:00
+
+cworld2j:
+0:ff0f68:04:00:01
+0:ff0f6c:9c:00:00
+
+dino:
+dinoj: 
+dinou:
+dinohunt:
+0:fff03e:310:00:00
+0:fff34e:010:99:00
+
+ghouls:
+ghoulsu: 
+daimakair:
+daimakai: 
+0:ffbf4c:78:48:a8
+0:ff087a:04:00:00
+
+mbombrd:  
+mbombrdj: 
+0:ffa0cc:02:00:10
+0:ffa0ce:ae:00:00
+
+megamana:
+megaman:
+rockmanj:
+mmancp2u:
+rmancp2j:
+mmancp2ur1:
+0:ffeed0:28:00:00
+0:ffef10:28:00:02
+
+mercs:
+mercsur1: 
+mercsj: 
+mercsua:
+0:ff0fd0:a0:00:20
+
+msword:
+mswordu: 
+mswordj: 
+mswordr1:
+0:fffe32:98:00:00
+0:fffeca:02:04:00
+0:ffa890:04:00:00
+
+nemo:
+nemoj: 
+nemor1:
+0:fff004:28:00:20
+0:fff054:14:ff:24
+0:fff07c:04:00:00
+
+pang3:
+pang3j: 
+pang3b:
+pang3r1:
+0:ff9726:8c:00:09
+
+pnickj:
+0:ff2574:28:03:00
+0:ff259e:50:03:00
+0:ff8534:04:00:00
+
+punisher:
+punisheru: 
+punisherj: 
+punisherbz:
+punisherh:
+0:ff7896:258:ff:01
+0:ff5b92:004:01:00
+
+qad:
+0:ffe96e:3c:00:70
+
+qadjr:
+0:ff4ba9:5f:dc:02
+qtono2j:
+0:ff50fe:64:00:00
+0:ff519e:60:00:00
+0:ff51fe:04:06:00
+
+sf2:
+sf2a:
+sf2b:
+sf2e:
+sf2j:
+sf2jb:
+sf2ua:
+sf2ub:
+sf2ue:
+sf2ja:
+sf2ebbl:
+sf2jc:
+sf2qp1:
+sf2uf:
+sf2ui:
+sf2uk:
+sf2eb:
+sf2thndr:
+sf2ee:
+sf2uc:
+sf2ug:
+sf2stt:
+sf2rk:
+sf2jf:
+sf2jh:
+sf2jl:
+sf2ed:
+sf2ebbl2:
+sf2ebbl3:
+0:ffd28a:30:00:20 
+0:ffd302:04:00:00            
+
+sf2accp2:
+0:ffd276:27:00:4b
+0:ffd2ee:4:00:00
+
+sf2red:
+0:ffd276:28:02:20
+0:ffd2ee:04:02:53
+
+slammast: 
+mbomberj: 
+0:ffa138:02:00:10
+0:ffa13a:ae:00:00
+
+unsquad:  ;******u.n. squadren
+area88:
+area88r: 
+0:ff101c:50:00:26
+0:ff107c:08:00:00
+
+;********crbaloon.c
+crbaloon: 
+crbaloon2: 
+0:4016:03:00:00
+0:417f:0a:11:00
+
+;********crimfght.c
+crimfght:
+crimfghtu:
+crimfgtj:
+crimfght2:
+0:1a40:46:00:19
+
+;********cvs.c
+cosmos:
+0:3c00:52:00:00
+
+hero:
+0:3c00:27:00:30
+
+herodku:
+herodk:
+0:3c44:50:00:00
+0:3c94:1:23:23
+
+;********darius.c
+darius:
+dariuse:
+dariusu:
+0:822f2:729:00:2e
+
+dariuso:
+dariusj:
+0:822ec:729:00:00
+0:82666:1:41:41
+
+;********darkseal.c
+darkseal:
+gatedoom:
+gatedoom1:
+darksealj:
+darkseal1:
+0:103e00:37:00:4d
+
+;********dday.c
+dday:
+ddayc:
+0:6237:3:00:00
+0:5379:5:20:20
+
+;********ddrible.c
+ddribble:
+ddribblep:
+0:4800:70:1d:03
+
+baddudes: ;[Special thanks to Cananas for enhancing this entry]
+0:ffa8fe:a0:4d:01 
+0:ff81d4:04:00:00 
+
+drgninja: 
+drgninjab:
+0:ffa8f8:a0:4d:01 
+0:ff81d4:04:00:00
+
+drgninjab2:
+0:ffa8f8:a8:4d:01
+0:ff81d4:04:00:00
+
+hbarrel:
+0:ffbe9c:58:00:26
+
+hbarrelw:
+0:ffbe78:58:00:26
+
+hippodrm:
+ffantasy:
+ffantasya:
+0:ffbe00:50:08:01
+
+;********dec8.c
+breywood: 
+0:0108:28:31:00
+0:006d:3:04:00
+
+cobracom:
+cobracmj:
+0:06c6:1e:00:54
+0:0135:3:00:76
+
+csilver:
+csilverj:
+0:c7a:1:0f:0f
+0:0e3c:3c:00:00
+0:0009:3:00:00
+
+garyoret:
+0:135f:28:00:00
+0:138b:1e:13:1c
+
+ghostb:
+ghostb2a:
+0:01c0:76:01:10
+
+ghostb3:
+0:0da0:76:01:10
+
+gondo:
+0:1532:48:21:00
+
+lastmisnj:
+lastmisn:
+lastmisno:
+0:09aa:3c:00:44
+0:0006:3:00:00
+
+makyosen:
+0:14f9:48:21:00
+
+oscar:
+oscarj1:
+oscarj2:
+oscaru:
+0:075a:46:00:33
+0:0006:3:00:09
+
+shackled: 
+0:0108:28:31:00
+0:006b:3:04:00
+
+srdarwin:
+srdarwinj:
+0:1342:46:00:4d
+0:1332:3:05:00
+
+;********deniam.c
+logicpro:
+croquis:
+0:ff0658:28:53:00
+
+logicpr2:
+0:ff70e6:46:0a:d0
+
+radarscp: 
+radarscp1:
+0:6307:a2:00:fc
+0:60a8:3:50:00
+0:7641:1:00:00
+0:7621:1:00:00
+0:7601:1:07:07
+0:75e1:1:06:06
+0:75c1:1:05:05
+0:75a1:1:00:00
+
+;********docastle.c
+bluehawk:
+bluehawkn:
+0:f0b6:32:03:06
+
+docastle:
+docastle2:
+douni:
+docastleo:
+0:8020:50:01:00
+
+dowild:
+jjack:
+kickridr:
+0:2020:50:01:00
+
+;********dooyong.c
+lastday:
+lastdaya:
+ddaydoo:
+0:d6ca:b:20:30
+0:e07e:6e:00:1b
+0:e138:7:00:00
+
+;********dowild.c
+dorunrun:
+dorunrun2:
+0:2010:190:00:50
+
+dorunrunca: ;******Do! Run Run (Do's Castle hardware, set 2)
+dorunrunc: ;******Do! Run Run (Do's Castle hardware, set 1)
+0:8010:190:00:50
+
+spiero:
+0:2010:3:00:00
+0:2011:1:10:10
+
+;********eprom.c
+eprom:
+0:3f7de8:c8:00:98
+
+eprom2:
+0:3f7dc0:c8:00:98
+
+;********espial.c
+espial:
+espialu:
+0:5842:78:00:27
+
+;********exctsccr.c
+exctsccr:
+exctsccru:
+exctsccra:
+exctsccrj:
+exctsccrjo:
+0:7c90:30:4d:00
+0:7c60:3:02:00
+
+exctsccrb:
+0:8c90:30:4d:00
+0:8c60:3:02:00
+
+;********exedexes.c
+exedexes:
+0:e680:50:00:19
+0:e600:8:00:00
+
+savgbees:
+0:e680:50:00:24
+0:e600:8:00:00
+
+;********exerion.c
+exerion:
+exerionb:
+exeriont:
+0:6600:c8:00:00
+0:6700:28:00:00
+
+;********exidy.c
+mtrap:
+mtrap3:
+mtrap4:
+mtrapb:
+0:0380:23:00:48
+
+venture:
+venture2:
+venture4:
+0:0380:23:00:53
+
+pepper2:
+hardhat:
+pepper27:
+0:0360:23:00:11
+
+targ:
+spectar:
+spectar1:
+phantoma:
+rallys:
+panzer:
+phantom:
+rallysa:
+0:00ae:2:00:10
+
+sidetrac: 
+0:000f:2:00:00
+
+;********fastfred.c
+fastfred:
+0:c04b:3:00:00
+0:c400:3f:00:11
+
+flyboy: 
+flyboyb:
+0:c400:1e:00:00
+0:c430:64:1b:10
+0:c04b:3:00:00
+
+;********finalizr.c
+finalizr:
+0:3c08:1:00:00
+0:3c09:1:03:03
+0:3c0a:2:00:00
+0:3bc0:27:00:12
+
+finalizrb:
+0:3c08:1:00:00
+0:3c09:1:02:02
+0:3c0a:2:00:00
+0:3bc0:27:00:12
+
+;********firetrap.c
+firetrapbl:
+firetrapj:
+0:ca47:5d:02:18
+
+firetrap:
+firetrapa:
+0:ca47:5d:02:25
+
+;********flstory.c (fairyland story)
+flstory:
+flstoryj:
+0:e74e:23:00:44
+
+;********frogger.c
+frogger:
+froggers1:
+froggers2:
+froggermc:
+quaak:
+froggeram:
+froggers3:
+0:83f1:A:63:01
+0:83ef:2:63:04
+
+frogf:  ;******Frogger (Falcon bootleg)
+0:83f0:c:04:05
+
+froggers:
+frogg:
+froggrs:
+0:43f1:0A:63:01
+0:43ef:02:63:04
+
+froggerv:
+0:83f1:0A:42:01
+0:83ef:2:42:04
+
+nebulbee:
+gatsbee:
+0:8a20:2d:00:0e
+0:83ed:6:00:24
+
+checkman:
+0:801c:48:00:00
+
+checkmanj:
+0:401b:48:00:00
+
+devilfsg:
+0:40a8:3:00:00
+
+jumpbug:
+jumpbugb:
+0:4222:15:00:97
+0:4208:6:00:00
+
+kingball:
+kingballj:
+0:8305:3:00:00
+0:800d:3:00:00
+0:8302:1:01:01
+
+levers:
+0:41cd:3:00:00
+
+moonal2:
+moonal2b:
+0:80a8:3:00:00
+0:83f4:2:ff:ff
+0:83FD:1:ff:ff
+
+moonqsr:
+0:804e:30:00:9f
+
+orbitron:
+0:404a:3:00:00
+
+pacmanbl:
+gmgalax:
+pacmanbla:
+0:4288:3:00:00
+0:5180:1:40:40
+0:51a0:1:40:40
+0:51c0:1:40:40
+0:51e0:1:40:40
+0:5200:1:40:40
+0:5220:1:40:40
+0:5240:1:48:48
+0:5260:1:47:47
+0:5280:1:49:49
+0:52a0:1:48:48
+
+pisces:
+omni:
+piscesb:
+0:4021:3:00:00
+
+;*updates score on 2nd game screen
+streakng:
+streaknga:
+0:4288:3:00:00
+0:5180:1:40:40
+0:51a0:1:40:40
+0:51c0:1:40:40
+0:51e0:1:40:40
+0:5200:1:40:40
+0:5230:1:10:10
+
+warofbug:  ;**** these 2 games have very buggy hiscore !  (ho ho ho) ****
+warofbugu:
+0:4034:3:00:00
+0:5241:1:0:0
+0:5221:1:0:0
+0:5201:1:0:0
+0:51e1:1:0:0
+0:51c1:1:0:0
+0:51a1:1:0:0
+
+
+;********galivan.c
+galivan2:
+galivan3:
+galivan:
+0:e14f:82:00:20
+0:e28e:3:00:00
+
+dangar:
+dangar2:
+dangarb:
+0:e209:82:00:20
+0:e394:3:00:00
+
+ninjemak:
+0:e469:41:00:20
+0:e4ac:3:00:00
+
+youma:
+youmab:
+youmab2:
+youma2:
+0:e469:41:00:3f
+0:e4ac:3:00:00
+
+;********galpanic.c
+fantasia:
+fantasiaa:
+fantasiab:
+fantasian:
+0:c825b6:63:30:20
+
+;********galspnbl.c
+galspnbl:
+0:701780:32:00:00
+0:700007:1:a3:a3
+
+;********gaplus.c
+gaplus:
+gapluso:
+galaga3m:
+gaplusa:
+galaga3:
+galaga3c:
+gaplusd:
+galaga3a:
+galaga3b:
+gaplust:
+0:03ED:08:30:20
+0:0900:A0:20:00
+0:09b6:03:00:00
+
+;********gauntlet.c
+; note saves last level completed and high scores
+gauntlet:
+gauntir1:
+gauntir2:
+gaunt2p:
+gauntletr4:
+gauntletr5:
+gauntletr7:
+gauntletr9:
+gauntlets:
+0:904010:2:0:7
+0:904DE8:C8:00:50
+
+; note saves last level completed and high scores
+gaunt2:
+0:904010:2:0:5
+0:904DE8:C8:00:E3
+
+;********gberet.c
+gberet:
+rushatck:
+gberetb:
+mrgoemon:
+0:d900:3C:03:13
+0:db06:03:03:00
+
+;********gbusters.c
+gbusters:
+crazycop:
+gbustersa:
+0:4100:38:19:00
+0:4050:4:00:00
+
+;********geebee.c
+geebee:
+geebeeg:
+geebeeb:
+0:4046:3:00:00
+
+;********gradius3.c
+gradius3:
+gradius3a:
+gradius3e:
+gradius3j:
+gradius3js:
+0:43f00:64:00:08
+0:40058:4:00:00
+0:4005a:1:73:73
+
+;********grobda.c
+grobda:
+grobda2:
+grobda3:
+0:1b00:a0:20:00
+0:0951:04:00:00
+
+;********gunsmoke.c
+gunsmoke:
+gunsmokeu:
+gunsmokeub:
+gunsmokeb:
+gunsmokeua:
+0:e680:50:00:14
+0:e600:8:00:00
+
+gunsmokej:
+0:e680:50:00:18
+0:e600:8:00:00
+
+;********hcastle.c 
+hcastle:
+hcastleo:
+hcastljo:
+hcastlej:
+akumajou:
+hcastlek:
+akumajoun:
+hcastlee:
+0:1940:3c:05:1a
+
+;********hexa.c
+hexa:
+hexaa:
+0:c709:2:00:00
+
+;********hyperspt.c 
+roadf:
+roadf2: 
+0:3bd0:10a:01:01
+0:3066:3:01:00
+
+;********ironhors.c
+ironhors:
+dairesya:
+farwest: 
+0:32f1:3:02:00
+0:3300:40:23:00
+
+;********itech8.c
+ninclown:
+0:8d:4e:00:44
+
+;********jack.c
+jack:
+jack2:
+jack3:
+treahunt:
+0:4500:5a:00:41
+
+;********jailbrek.c
+jailbrek:
+jailbrekb:
+manhatan:
+0:1620:50:00:11
+0:157e:3:00:30
+
+;********junofrst.c
+junofrst:
+junofrstg: 
+0:8100:a0:01:3f
+
+diamond:
+0:1200:80:4b:00
+
+;********gottlieb.c
+reactor:
+0:04d8:80:0a:00
+0:05bc:80:12:00
+
+;********gyruss.c
+gyruss:
+gyrussce:
+gyrussb:
+0:9488:28:00:83
+0:940b:03:00:01
+
+;********kaneko16.c 
+berlwall:
+berlwallt:
+berlwallk:
+0:2028a0:93:00:47
+
+;********kchamp.c
+kchamp:
+karatedo:
+kchampvs:
+karatevs:
+kchampvs2:
+0:c040:6c:02:01
+0:c0c0:3:02:00
+
+;********kingobox.c
+kingofb:
+0:C22A:04:00:05
+1:8048:8C:00:12
+
+ringking:
+ringking2:
+1:8049:8C:00:12
+0:C23B:04:00:05
+
+cavenger:
+0:6025:41:00:28
+
+snapjack:
+0:6a94:41:01:24
+
+;********lasso.c
+lasso:
+0:0220:70:11:30
+0:001c:3:00:00
+
+;********lastduel.c
+lastduel:
+lastduelo:
+lastduelb:
+0:ff87e2:4:00:00
+0:ffc6f2:68:c7:00
+0:fcc76d:1:20:20
+0:fcc7ed:1:20:20
+0:fcc86d:1:20:20
+0:fcc8ed:1:02:02
+0:fcc96d:1:00:00
+0:fcc9ed:1:00:00
+0:fcca6d:1:00:00
+0:fccaed:1:00:00
+
+madgear:
+madgearj:
+ledstorm:
+0:ff8890:78:00:00
+0:ffcb76:23:02:00
+0:ff87c9:1:d2:d2
+
+ledstorm2:
+leds2011u:
+leds2011:
+0:ff8890:78:00:00
+0:ffcb76:23:41:01
+0:ff87c9:1:d2:d2
+
+jungler:
+junglers:
+savanna:
+jackler:
+0:9940:a0:00:5b
+0:991c:3:00:02
+
+commsega:
+0:9c6d:6:00:00
+
+;********lwings.c
+avengers:
+avengers2:
+0:ce00:54:00:47
+0:ce97:3:00:60
+
+buraiken:
+buraikenb:
+0:ce00:5b:00:2e
+0:ce97:3:00:60
+
+lwings:
+lwings2:
+lwingsj:
+lwingsb:
+0:ce00:5b:00:2e
+0:ce97:d:00:00
+
+trojanr:
+trojan:
+trojanj:
+trojana:
+trojanb:
+0:ce00:5b:00:2e
+0:ce97:3:00:60
+
+;********m62.c
+kungfum:
+kungfumd:
+kungfub:
+kungfub2:
+spartanx:
+spartanxtec:
+0:ea06:78:00:41
+0:e980:3:52:00
+
+battroad:
+0:ed50:b0:00:08
+
+spelunk2:
+0:e066:64:99:3f
+0:e04f:2:99:11
+
+lotlot:
+0:e96b:226:02:00
+0:e956:3:02:17
+
+ldrun:
+ldruna:
+0:e5e5:c8:01:04
+0:e59a:3:04:40
+
+ldrun2:
+ldrun3:
+ldrun3j:
+0:e6bd:c8:00:05
+0:e672:3:00:80
+
+ldrun4:
+0:e735:c8:00:06
+0:e6ea:3:00:70
+
+
+;********m72.c
+airduelm72:
+airduel:
+0:a3d4e:82:15:20
+
+ripoff:
+0:e0:8:00:00
+
+hharry:
+0:a09a0:9f:00:20
+0:a0a40:03:00:00
+
+hharryu:
+0:e09a0:9f:00:20
+0:e0a40:03:00:00
+
+dkgensan:
+0:e09a0:9f:40:20
+0:e0a40:3:40:02
+
+imgfight:
+imgfighto:
+imgfightj:
+0:a334f:78:09:20
+
+majtitle:
+majtitlej:
+0:d2ba4:9b:4b:17
+
+nspirit:
+nspiritj:
+0:a3930:78:45:4f
+0:a39ba:03:45:00
+
+poundfor:
+poundforu:
+poundforj:
+0:e2502:28:10:00
+0:e252a:28:35:00
+0:e2552:28:42:00
+0:e257a:28:00:00
+0:e25a2:28:11:00
+0:e25ca:28:59:00
+0:e25f2:28:68:00
+0:e261a:28:70:00
+0:e2642:28:57:00
+0:e266a:28:41:00
+
+rtype2:
+rtype2j:
+rtype2jc:
+0:e3834:82:00:41
+0:e38c2:7:f3:30
+0:d0178:1:f3:f3
+0:d017c:1:31:31
+0:d0180:1:37:37
+0:d0184:1:34:34
+0:d0188:1:35:35
+0:d018c:1:30:30
+0:d0190:1:30:30
+
+rtype2m82b:
+0:d3848:6e:00:41
+
+;********m79amb.c
+m79amb:
+0:4008:1:00:00
+
+;********m90.c
+bombrman:
+0:a0b1b:8c:03:63
+0:a0bfe:3:40:00
+
+;********m92.c
+hooku:
+hook:
+0:ea6ad:ec:00:4f
+
+rtypeleo:
+rtypeleoj:
+0:e221e:38:40:20
+0:e2256:3:40:01
+0:dc148:1:20:20
+0:dc14c:1:31:31
+0:dc150:1:32:32
+0:dc154:1:38:38
+0:dc158:1:34:34
+0:dc15c:1:30:30
+0:dc160:1:30:30
+
+;*********metro.c (last fortress - toride / erotic)
+lastfort:
+lastforte:
+lastfortk:
+lastfortea:
+0:40db1a:0a:01:64
+
+;********Last Fortress - Toride (German)
+lastfortg:
+0:c0db1a:0a:01:64
+
+;********m97.c
+bbmanwj: ;**** top score not working ????? 
+bbmanw:
+bomblord:
+bbmanwja:
+0:a0b36:6a:02:2e
+
+dynablst:
+atompunk:  ;******atomic punk (us)
+dynablstb:
+0:a0b2c:8f:03:03
+0:a0c0f:3:40:00
+
+;********magix.c
+magix:
+0:f800:80:00:2e
+0:f888:3:00:01
+
+;********magmax.c
+magmax:
+0:18ce0:46:00:00
+0:18d2e:4:00:00
+0:18d23:1:35:35
+
+;********mainevt.c
+devstors:
+0:41c4:2e:01:01
+
+digdug2:
+digdug2o:
+0:11b0:50:00:01
+0:100b:3:00:00
+0:7ed:7:30:20
+
+motos:
+0:2400:a0:20:00
+0:1831:4:00:00
+
+todruaga:
+todruagb:
+todruagao:
+todruagas:
+0:102a:32:00:45
+0:100b:3:00:00
+
+;********marineb.c
+marineb:
+0:8979:6:24:24
+0:8999:6:00:00
+
+springer:
+0:8afa:5:00:00
+0:8b1a:5:00:00
+0:8b3a:5:02:02
+0:8b5a:5:00:00
+0:8b7a:5:00:00
+0:8b9a:5:00:00
+0:8bba:5:00:00
+
+hoccer:
+0:8550:32:00:01
+0:85ca:6:00:00
+
+hoccer2:
+0:8550:2d:00:29
+0:85ca:6:00:00
+
+hopprobo:
+0:805f:19:00:00
+0:8078:1e:1c:0e
+0:89be:1:00:00
+0:89de:1:01:01
+0:89fe:1:06:06
+0:8a1e:1:07:07
+0:8a3e:1:00:00
+
+wanted: ;* not saving whole table
+0:8a5e:1:00:00
+0:8a3e:1:03:03
+0:8a1e:1:00:00
+0:89fe:1:00:00
+0:89de:1:00:00
+0:81b4:4c:00:16
+
+;********mario.c
+mario:
+masao:
+marioj:
+marioo:
+marioe:
+mariobl:
+0:6b00:aa:97:74
+0:6c00:3c:00:00
+0:6823:3:01:00
+
+;********matmania.c
+matmania:
+excthour:
+0:0700:50:00:b0
+0:0028:3:00:00
+
+maniach:
+maniach2:
+0:052b:3c:00:c6
+0:0028:3:00:00
+
+;********mcr3.c
+destderb:
+0:e4e4:ce:01:00
+0:e7f7:1:76:76
+
+;********mcr68.c
+archrivl:
+0:62cf1:319:09:05
+0:61ed5:1:03:03
+
+archrivl2:
+archrivla:
+archrivlb:
+0:62ce3:319:09:05
+0:61ed5:1:03:03
+
+blasted:
+0:61d7f:2f:54:75
+
+zwackery:
+0:842c2:48:42:00
+
+;********megasys1.c
+64street:
+64streetj:
+64streetja:
+0:ff8843:74:00:43
+
+avspirit:
+0:79df2:53:00:54
+
+chimerab:
+0:ff8850:a7:00:00
+
+p47:
+p47j:
+p47je:
+0:f1800:78:00:4f
+
+phantasm:
+0:ff9dee:53:00:54
+
+plusalph:
+0:f2f36:168:00:43
+
+rodland:
+0:f60fc:226:00:01
+0:f3030:14:00:00
+
+rodlandj:
+rodlandjb:
+0:f60fa:226:00:01
+0:f302e:13:00:00
+
+rittam:
+0:f68fc:226:00:01
+0:f3d3e:14:00:df
+
+;********metro.c
+skyalert:
+0:c0e340:5c:00:08
+
+;********mikie.c
+mikie:
+mikiej:
+mikiehs:
+0:2a00:01:1d:1d 
+0:2a01:01:2c:2c 
+0:2a02:01:1f:1f 
+0:2a03:01:00:00 
+0:2a04:01:01:01 
+0:2a05:28:00:00 
+0:29f0:04:00:00 
+0:297c:04:00:00 
+
+;********mitchell.c
+block:
+blockr2:
+blockr1:
+blockj:
+blockbl:
+blockjoy:
+0:e0f0:50:54:85
+
+;********mnight.c
+mnight:
+0:c099:41:00:20
+0:c0e6:3:00:00
+
+arkarea:
+0:d45c:42:46:30
+0:c040:3:00:00
+
+;********mole.c
+mole:
+00:02E1:0A:00:05
+00:0375:50:19:00
+
+;********mpatrol.c
+mpatrol: 
+mpatrolw: 
+mranger: 
+0:e008:2c:00:00
+
+;********mrdo.c
+mrdo:  
+mrdot:
+mrdofix:
+mrlo:
+mrdu:
+mrdoy:
+yankeedo:
+0:e017:64:01:00
+
+;********namcos1.c
+blastoff:
+0:4160:91:00:47
+0:4030:4:00:00
+0:400e:1:fe:fe
+
+dangseed:
+0:053f:a0:01:01
+0:0527:4:00:00
+
+dspirit:
+dspirit1:
+dspirit2:
+0:4092:32:00:01
+0:40d0:3:00:00
+
+galaga88:
+galag88b:
+galaga88j:
+galaga88a:
+0:4a0d:6:00:00
+0:4b75:60:00:01
+
+quester:
+0:360:50:00:60
+0:130:4:00:00
+
+rompers:
+romperso:
+0:401:4f:00:01
+0:143:3:00:88
+0:13a:8:00:00
+
+;********namcos2.c
+assault:
+assaultj:
+assaultp:
+0:101800:4d:00:20
+0:100058:4:00:00
+
+cosmogng:
+cosmogngj:
+0:10a003:f7:01:0d
+0:10080e:3c:00:70
+
+rthun2:
+rthun2j:
+0:1066e8:64:00:4f
+0:100020:4:00:00
+
+;********namcos86.c
+hopmappy:
+0:4c41:3:00:00
+0:4ca0:81:00:62
+0:209e:1:2e:2e
+0:20a0:1:2e:2e
+0:20a2:1:08:08
+0:20a4:1:00:00
+0:20a6:1:00:00
+0:20a8:1:00:00
+
+rthunder:
+rthunder1:
+rthunder2:
+rthunder0:
+rthundera:
+0:5400:23:00:12
+0:5450:3:00:00
+
+;********nemesis.c
+citybomb:
+citybombj:
+0:80700:50:00:22
+0:8005c:4:00:00
+0:80156:2e:01:50
+
+konamigt:
+0:60105:1:00:00
+0:60106:2:10:00
+0:61480:328:4a:01
+
+gradius:
+0:195f0:8c:00:00
+0:70098:4:00:00
+0:7009a:1:73:73
+
+;* top score not saved
+nyanpani:
+0:42800:28:00:10
+
+salamand:
+salamandj:
+lifefrce:
+lifefrcej:
+0:085000:64:00:16
+0:08005a:4:00:00
+
+;********ninjaw.c
+darius2:
+0:c216e:44b:00:20
+
+darius2d:
+darius2do:
+sagaia:
+0:1010fa:44b:00:20
+
+;********nova2001.c 
+;****note doesnt save top scores
+nova2001u:
+nova2001:
+nova2001h:
+0:a0ac:7:22:14
+0:e07d:37:00:20
+
+;********ohmygod.c
+naname:
+0:70e810:4f:4e:00
+
+ohmygod:
+0:704440:e8:01:00
+0:705900:4:00:00
+
+robokid:
+0:e0a4:f:00:00
+0:e0b3:f:46:49
+0:e0d0:4:00:00
+
+robokidj:
+robokidj2:
+robokidj3:
+0:e0a4:41:00:20
+0:e0f3:3:00:00
+
+;********omegrace
+omegrace:
+deltrace:
+0:43a9:7e:50:48
+0:4be8:1:08:08
+
+crush:
+maketrax:
+maketrxb:
+korosuke:
+0:4C80:03:00:00
+0:4E40:1E:4B:00
+
+crush2:
+crush3:
+mbrush:
+paintrlr:
+crushbl2:
+crushs:
+crushbl3:
+0:43D2:02:49:48
+0:4C80:03:00:00
+
+;******Crush Roller (Kural TWT)
+crush4:
+0:4c80:3:00:00
+0:4c83:1:04:04
+
+crushbl:  ;******Crush Roller (bootleg)
+0:4e40:2e:48:00
+0:4c80:3:00:00
+
+mrtnt:
+gorkans:
+0:4cb3:3c:4c:01
+0:43ed:6:00:40
+
+;********pingpong.c
+pingpong:
+0:94b1:3c:02:23
+0:949e:3:02:00
+0:846d:6:10:00
+
+;********phozon.c
+phozon:
+phozons:
+0:1409:30:00:59
+0:105d:3:00:00
+0:03ee:7:30:20
+
+;********pkunwar.c
+pkunwar:
+pkunwarj:
+0:c187:3c:00:00
+0:c1d6:2:00:20
+0:c1d8:1:00:00
+
+;********pooyan.c
+pooyan:
+pooyans:
+pootan:
+0:89c0:1e:00:00
+0:8a00:1e:00:01
+0:8e00:1e:00:00
+0:88a8:3:00:01
+
+;********pow.c
+pow:
+powj:
+0:43e8e:4:00:00
+0:41910:2:00:01
+0:41912:4E:00:00
+
+;********psikyo.c
+gunbird:
+gunbirdj:
+gunbirdk:
+0:fe3dd0:75:00:2d
+
+sngkace:
+sngkacea:
+0:fe7d88:9e:00:04
+
+;********psychic5.c
+psychic5:
+psychic5a:
+psychic5j:
+0:fd00:30:00:59
+0:fc84:3:00:53
+
+punchout: ;[Special thanks to Cananas for enhancing this entry]
+punchita:
+punchoutj:
+punchouta:
+0:d660:50:41:04
+
+spnchout: ;[Special thanks to Cananas for enhancing this entry]
+spnchoutj:
+0:d5c0:f0:21:04
+
+;********qwakprot.c
+qwakprot:
+qwak:
+0:0045:3:00:00
+0:0108:3:4d:43
+
+;********raiden.c
+raidenb:
+0:000c27:b3:50:2e
+
+raidenua:
+0:000c47:b3:50:2e
+
+raidena:
+raident:
+raiden:
+raidenk:
+raidenu:
+0:000bd7:b4:50:00
+
+;********rallyx.c
+rallyx:
+rallyxa:
+rallyxm:
+nrallyx:
+nrallyxb:
+rallyxmr:
+0:8060:8:00:02 
+
+;********renegade.c
+renegade:
+0:101b:28:00:4c
+0:2e:3:00:05
+
+fantasy:
+fantasyj:
+0:0025:3:00:00
+0:0220:30:11:30
+
+
+;********rocnrope.c
+rocnrope:
+rocnropek:
+ropeman:
+0:5160:40:01:00
+0:50A6:03:01:00
+
+;********rollrace.c
+fightrol:
+rollrace:
+rollace:
+0:c060:3e:00:11
+0:c026:3:00:00
+
+;********rpunch.c
+rpunch:
+0:ffe01:73:00:17
+
+rabiolep:
+0:ffe01:77:00:80
+
+armorcar:
+armorcar2:
+0:8113:3c:02:50
+
+rescue:
+aponow:
+0:80f3:3c:01:4d
+
+rescuefe:
+0:06f3:3c:01:4d
+
+scobra:
+scobras:
+scobrab:
+scobrase:
+scobrae:
+0:8200:1e:00:01
+0:80a8:03:00:01
+
+spdcoin:
+0:80ce:687:25:00
+0:8a42:1:00:00
+0:8a62:1:00:00
+0:8a82:1:00:00
+0:8aa2:1:00:00
+0:8ac2:1:00:00
+0:8ae2:1:00:00
+0:8b02:1:00:00
+
+stratgyx:
+stratgys:
+strongx:
+0:80a8:3:00:00
+0:81c0:1e:00:00
+0:81dc:1:13:13
+
+;******scramble.c
+atlantis:
+atlantis2:
+atlantisb:
+0:403d:2c:00:00
+
+cavelon:
+0:42ff:4:00:00
+0:4304:0d:00:15
+
+scramble: ;[Special thanks to Cananas for enhancing this entry]
+scrambls:
+scramblb:
+scramblebf:
+scramblebb:
+bomber:
+scrambles2:
+scrambler:
+scrambp:
+scrampt:
+scramrf:
+scramce:
+0:4200:1e:00:01
+0:40a8:03:00:01
+
+explorer: 
+0:4200:1e:49:01
+0:40a8:03:00:01
+
+mars:
+0:4200:12:00:01
+0:40a8:3:00:01
+0:4a41:1:10:10
+0:4a21:1:01:01
+0:4a01:1:00:00
+0:49e1:1:00:00
+0:49c1:1:00:00
+0:49a1:1:00:00
+
+theend:
+theends:
+0:43c0:0f:00:00
+0:40a8:03:00:00
+
+spacfury:
+spacfurya:
+0:c924:3d:90:00
+0:cfd2:1e:00:09
+
+startrek:
+0:c910:72:25:31
+0:c98b:1b:53:50
+
+tacscan:
+0:cb44:0f:4d:48
+0:cb95:0f:02:00
+
+;********segac2.c 
+borench:
+borencha:
+0:fff410:44:4d:05
+
+puyopuyo:
+puyo:
+puyoj:
+puyoja:
+puyobl:
+puyopuya:
+puyopuyb:
+0:fffce2:4c:13:98
+
+puyopuy2:
+0:ff4830:4c:53:98
+
+tfrceac:
+tfrceacb:
+tfrceacj:
+0:ff8100:e4:00:09
+0:fff1ac:4:00:10
+
+pignewt:
+0:cfd2:1e:57:4e
+0:ce0c:61:12:60
+
+pignewta:
+0:cfd2:1e:57:4e
+0:ce0c:61:02:60
+
+;********seicross.c
+radrad:
+0:7802:3:02:00
+0:91ba:6:24:00
+
+;********senjyo.c
+senjyo:
+0:8060:3:00:00
+0:8080:38:00:06
+0:9261:1:24:24
+0:9241:1:24:24
+0:9221:1:24:24
+0:9201:1:24:24
+0:91e1:1:24:24
+0:91c1:1:24:24
+0:91a1:1:00:00
+0:9181:1:00:00
+
+;********seta.c
+arbalest:
+0:f018cd:8b:00:14
+
+eightfrc:
+0:20c526:5f:00:43
+0:20c5bf:1:7a:7a
+
+oisipuzl:
+0:20d25f:4e:00:16
+
+metafox:
+0:f014e6:8c:00:14
+
+tndrcade:
+tndrcadej:
+0:e00301:96:00:2e
+
+thunderl:
+thunderlbl:
+0:ffe108:cc:00:41
+
+twineagl:
+0:ffc09c:3b:00:2e
+
+wrofaero:
+0:3006a4:71:00:3f
+
+zingzip:
+0:2028fd:69:00:a2
+
+;********shaolins.c
+kicker:
+shaolins:
+shaolinb:
+0:2af1:2:02:58
+0:2af3:1:00:00
+0:2b00:3e:1d:01
+0:2b3e:2:00:00
+
+;********sharkatt.c
+sharkatt:
+0:806e:50:30:20
+
+;********sidearms.c 
+dyger:
+dygera:
+0:c0d0:23:37:06
+0:c086:2:37:37
+
+;********sidepckt.c
+sidepckt:
+sidepcktb:
+sidepcktj:
+0:a0e:32:11:54
+
+;********skyfox.c
+skyfox:
+0:de00:a:00:00
+0:df00:23:00:00
+
+exerizerb:
+exerizer:
+0:de00:a:00:00
+0:df00:28:00:00
+0:D356:1:A0:A0
+0:D35A:1:A0:A0
+0:D35E:1:A0:A0
+0:D362:1:A0:A0
+0:D366:1:00:00
+0:D36A:1:00:00
+
+;********snk.c
+aso:
+0:d83b:82:00:20
+0:e777:3:00:00
+
+arian:
+0:d83b:82:00:20
+0:ee77a:3:00:00
+
+fitegolf:
+fitegolf2:
+fitegolfu:
+0:ff70:50:53:14
+
+tnk3:
+tnk3j:
+0:fed1:82:13:20
+0:fc59:3:00:00
+
+victroad:
+dogosoke:
+dogosokb:
+0:ff2c:50:00:55
+0:fc5f:3:00:00
+
+gwar:
+gwarj:
+gwara:
+gwarb:
+0:e4b9:50:00:52
+0:e3ae:3:00:00
+
+bermudat:
+bermudatj:
+0:febe:50:00:4f
+0:e3ce:3:00:00
+
+bermudata:
+0:fec2:50:00:20
+0:e3ce:3:00:00
+
+worldwar:
+0:fec2:50:00:44
+0:e3ce:3:00:00
+
+psychos:
+psychosj:
+0:dd05:f5:31:ff
+0:fe66:3:00:00
+
+chopper:
+legofair:
+choppera:
+chopperb:
+0:e4c5:3c:00:4b
+0:e462:3:00:00
+
+tdfever:
+tdfeverj:
+tdfever2:
+0:df28:28:c5:00
+
+fsoccer:
+0:e349:14:48:01
+
+;********sonson.c
+sonson:
+sonsonj:
+0:d8:4:00:00
+0:300:64:00:1d
+
+;********solomon.c
+solomon:
+solomonj:
+0:ca4c:5a:50:01
+
+;********srumbler.c
+srumbler: ;[Special thanks to Wob for enhancing this entry]
+srumbler2:
+rushcrsh:
+srumbler3:
+0:1c94:70:54:f2
+0:aa:4:00:00
+
+;********starwars.c
+esb:
+0:4b3f:af:0f:90
+
+;********spdodgeb.c
+spdodgeb:
+nkdodge:
+nkdodgeb:
+0:83:3:00:00
+
+;********superman.c
+ballbros:
+0:f00ebe:63:00:20
+
+twinhawk:  ;***** top scor updates on game start *****
+twinhawku:
+daisenpu:
+0:f00132:40:00:aa
+
+gigandes:
+0:f00a86:57:00:4e
+0:f00964:4:00:00
+
+gigandesa:
+0:f00a86:53:00:52
+0:f00964:4:00:00
+
+;********superpac.c
+superpac:
+superpacm:
+0:1138:28:00:20
+0:1087:3:00:00
+0:3ee:7:30:20
+
+pacnpal:
+pacnchmp:
+pacnpal2: 
+0:104c:28:00:23
+0:116d:3:00:00
+0:3ed:7:00:24
+
+;********superqix.c
+sqixbl:
+0:f4c0:28:00:03
+0:f8f1:4:75:00
+
+;********surpratk.c
+;* you must exit this game while in-game top score is displaying (not highscore table)*
+;* for in-game top score to save correctly(because of way game uses videoram)
+surpratk:
+0:b00:5a:11:31
+0:5980:4:00:00
+0:609e:6:01:00
+
+;********system1.c
+4dwarrio: ;[Special thanks to Cananas for enhancing this entry]
+0:d300:a0:00:20
+0:c017:3:00:02
+
+chopliftu:
+chplftbl:
+choplift:
+chopliftbl:
+0:ef00:31:00:4b
+0:ef71:4:00:00
+
+hvymetal:
+0:d300:38:00:59
+0:c00c:3:00:00
+
+myhero:
+0:d300:3c:00:49
+0:c017:3:00:00
+
+myherok:
+sscandal:
+myherobl:
+0:d300:a0:00:20
+0:c017:3:00:00
+
+swat:
+0:d300:3c:00:49
+0:c014:3:00:02
+
+wboy:
+wboy2:
+wboy3:
+wboy4:
+wboy4u:
+wboyu: ;*note* only 1/2 works... 
+wbdeluxe:
+wboyo:
+wboy2u:
+wboy5:
+0:c100:140:20:20
+0:e856:f:01:10
+
+wboysys2:  ;******Wonder Boy (system 2)
+0:c100:140:20:20
+0:e056:f:01:10
+
+wbmljo:
+wbmljb:
+wbml:
+wbmlbg: 
+wbmlbge:
+wbmlvc:
+wbmld:
+wbmljod:
+wbmlvcd:
+0:c101:1:24:24
+0:072f:1:03:03
+0:c179:1:00:00
+0:c17a:1:00:00
+0:c17b:1:00:00
+0:c17c:1:00:00
+0:c17d:1:03:03
+0:c17e:1:00:00
+0:c17f:1:00:00
+0:c180:1:00:00
+
+;********system1.c (wonder boy in monster land (bootleg)**fix**))
+wbmlb:
+0:c179:8:00:00
+0:c17d:1:03:03
+
+;********system16.c
+aburner:
+0:ff846e:117:00:00
+0:ff857f:1:4f:4f
+
+aburner2:
+aburner2g:
+0:ff846e:117:00:00
+0:ff846f:1:70:70
+
+fantzone:
+fantzoneta:
+0:fffc00:38:00:52
+0:ffc22c:4:00:00
+
+fantzono:
+fantzonep:
+fantzonepr:
+fantzone1:
+0:fffc00:38:00:95
+0:ffc22c:4:00:00
+
+hwchamp:
+hwchampj:
+hwchampjd:
+0:fff400:318:10:00
+
+tetrisbl:
+0:ffe800:64:45:08
+
+tetrist:
+0:8045ac:64:45:08
+
+;******Tetris (Japan, B-System, YM2203)
+tetrista:
+0:8023ac:64:45:08
+
+;******Tetris (Japan, System 16A, FD1094 317-0093a)
+tetris2:
+tetris3:  ;******tetris (Japan, System 16A, FD1094 317-0093)
+tetris:
+tetris1:
+tetris1d:
+tetris2d:
+tetris3d:
+tetrisd:
+0:ffe800:64:45:08
+
+timscanr:
+timescn:
+0:ffc036:1:00:00
+0:ffc037:2:01:20
+0:ffc039:1:00:00
+0:fff750:46:00:00
+
+;********tail2nos.c
+tail2nos:
+sformula:
+sformulaa:
+0:ff89c4:130:0a:00
+0:ff8b05:f:40:00
+
+;********taitosj.c
+alpine:
+alpinea:
+0:8082:3:00:00
+0:c5be:1:25:25
+0:c5de:1:25:25
+0:c5fe:1:05:05
+0:c61e:1:00:00
+0:c63e:1:00:00
+0:c65e:1:00:00
+
+elevator:
+elevatorb:
+0:8350:3:00:01
+
+frontlin:
+0:8640:3:01:00
+0:c5be:1:00:00
+0:c5de:1:01:01
+0:c5fe:1:00:00
+0:c61e:1:00:00
+0:c63e:1:00:00
+0:c65e:1:00:00
+
+hwrace:
+0:80c0:3:00:00
+0:80c1:1:50:50
+
+junglek:
+jungleh:
+junglehbr:
+junglekj2:
+jungleby:
+junglekas:
+0:816b:1:00:00
+0:816c:1:50:50
+0:816d:1:00:00
+
+piratpet:
+0:816c:1:00:00
+0:816d:1:50:50
+0:816e:1:00:00
+
+tinstar:
+tinstar2:
+0:835d:1:00:00
+0:835e:1:01:01
+0:835f:1:00:00
+
+wwestern:
+wwestern1:
+0:8630:5c:01:ba
+0:c5be:2:00:1d
+0:c5de:2:01:0a
+0:c5fe:2:00:12
+0:c61e:2:00:1d
+0:c63e:2:00:18
+0:c65e:1:00:00
+
+;********taito_b.c
+ashura:
+ashuraj:
+0:6019f4:64:00:19
+0:6012a2:2:00:00
+0:6012a4:2:10:00
+
+crimec:
+crimecj:
+crimecu:
+0:a02fba:4:00:00
+0:a0e005:4af:54:00
+
+selfeena:
+0:10338e:3a:41:00
+0:102481:1:19:19
+0:102483:1:0c:0c
+
+spacedx:
+spacedxj:
+0:902701:3:00:00
+0:90ff9b:1:37:37
+
+spcinvdj:
+0:404f73:3:00:00
+
+;********taito_f2.c
+cameltry:
+;*note cant see highscore table in cameltry so its commented out
+;cameltru: 
+0:106c9e:244:35:44
+0:1066b0:3e:06:00
+0:105430:4:00:00
+
+deadconx:
+deadconxj:
+0:10335a:59:00:47
+
+dondokod:
+dondokodu:
+dondokodj:
+0:1028e8:28:00:55
+ 
+gunfront:
+gunfrontj:
+0:10922c:54:00:30
+0:10922e:1:c3:c3
+ 
+liquidk:
+liquidku:
+mizubaku:
+0:10B0FE:28:00:55
+
+metalb:
+metalbj:
+0:10e3aa:28:00:04
+0:10d0b0:4:00:50
+
+ssi:
+ssia:
+0:205814:31:00:5a
+0:203606:4:00:00
+
+majest12:
+majest12j:
+majest12u:
+0:205812:31:00:5a
+0:203606:4:00:00
+
+arkretrn:
+arkretrnj:
+arkretrnu:
+0:401a1a:27:00:17
+
+bubblem:
+bubblemj:
+0:40f2ec:10e:00:08
+0:407135:3:27:13
+0:40eb04:50:00:00
+
+
+bublbob2o:
+bubsymphj:
+bubsymphu:
+bubsymphe:
+bubsymphb:
+bublbob2:
+0:40ed6c:96:00:07
+0:40ed8d:1:06:06
+0:40ea20:84:00:00
+
+gseeker:
+gseekerj:
+gseekeru:
+0:4107ba:50:00:f8
+0:40d176:4:00:50
+
+gunlock:
+rayforce:
+rayforcej:
+0:40eff4:40:41:00
+0:4022fa:4:01:00
+
+;********taito_l.c
+fhawk:
+fhawkj:
+0:a2fe:50:50:2e
+0:a24e:3:50:00
+
+palamed:
+0:8206:2e:20:52
+
+plgirls2:
+plgirls2b:
+0:81e0:35:00:05
+
+;********tankbatt.c
+tankbatt:
+tankbattb:
+0:00c3:02:00:00
+
+rygar:
+rygar2:
+rygarj:
+rygar3:
+0:c983:1c4:41:0
+0:c023:2:0:0
+0:c025:1:03:03
+0:c026:1:0:0
+0:d06c:8:1:60
+
+silkworm:
+silkwormj:
+0:d262:64:00:10
+0:c848:18:20:30
+0:d54e:4:00:00
+0:d572:4:00:00
+
+;********terracre.c
+terracren:
+terracre:
+terracrea:
+terracreo:
+0:20246:46:00:00
+0:2028c:4:00:00
+0:20248:1:50:50
+
+;********thepit.c
+fitter:
+roundup:
+fitterbl:
+ttfitter:
+0:8050:03:00:00
+0:9621:01:24:24
+0:9601:01:24:24
+0:95E1:01:24:24
+0:95C1:01:24:24
+0:95A1:01:24:24
+0:9581:01:00:00
+
+machomou:
+0:804a:3:00:00
+0:9181:1:00:00
+0:91a1:1:24:24
+0:91c1:1:24:24
+0:91e1:1:24:24
+0:9201:1:24:24
+0:9221:1:24:24
+
+suprmous:
+0:804A:03:00:00
+0:9221:01:24:24
+0:9201:01:24:24
+0:91E1:01:24:24
+0:91C1:01:24:24
+0:91A1:01:24:24
+0:9181:01:00:00
+
+;********thief.c
+thief:
+0:8abc:49:30:20
+
+;********thunderx.c
+scontra:
+scontraj:
+0:4100:50:11:00
+0:4050:1:00:00
+0:4051:3:01:00
+
+;********tnzs.c
+chukatai:
+chukataij:
+chukataiu:
+0:ed8c:46:00:42
+0:e210:3:00:75
+
+drtoppel:
+drtoppelu:
+drtoppelj:
+0:e057:23:00:25
+0:e023:3:00:00
+
+insectx:
+insectxj:
+0:c600:50:00:00
+0:c6ea:3:00:21
+
+plumppop:
+0:c625:27:00:52
+0:e471:3:00:00
+
+tnzs2:
+0:ec0a:23:00:55
+
+hellfire1:
+hellfire3:
+hellfire1a:
+0:42130:c2:00:08
+0:421e9:1:14:14
+0:42357:21:2e:30
+
+hellfire:
+hellfire2:
+hellfire2a:
+0:42300:c2:00:08
+0:423b9:1:14:14
+0:42529:21:2e:30
+
+rallybik:
+0:801ac:324:00:40
+0:8053d:1:17:17
+0:80555:1:04:04
+0:8056d:1:00:00
+0:80585:1:00:00
+0:8059d:1:00:00
+0:805b5:1:00:00
+
+truxton:
+0:0819de:16c:00:0b
+0:81c53:1:2d:2d
+0:81c57:1:2d:2d
+0:81c5b:1:2d:2d
+0:81c5f:1:2d:2d
+0:81c63:1:05:05
+0:81c67:1:00:00
+0:81c6b:1:00:00
+0:81c6f:1:00:00
+0:81c73:1:00:00
+
+samesame:
+0:c1778:194:00:01
+0:c18b9:1:26:26
+0:c1a4f:21:2d:00
+
+samesame2:
+0:c1ada:194:00:01
+0:c1c25:1:26:26
+0:c1dc1:21:2d:00
+
+;*note* top score does not display
+vimana:
+vimanan:
+vimana1:
+vimanaj:
+0:480198:f4:00:41
+
+;** only saves high table (no top score)
+;** and highscore counter (not display)
+zerowing1:
+0:81776:68:00:10
+0:81778:1:50:50
+
+zerowingw:
+zerowing:
+0:81a1e:68:00:10
+0:81a20:1:50:50
+
+grindstm:
+0:100500:90:00:00
+0:10057f:1:2d:2d
+0:10043c:4:00:00
+
+grindstma:
+0:1004fc:90:00:00
+0:10057b:1:2d:2d
+0:100438:4:00:00
+
+vfive:
+0:1004fa:90:00:00
+0:100436:4:00:00
+0:100579:1:2d:2d
+
+pipibibs:
+pipibibsbl:
+pipibibsa:
+pipibibsp:
+0:0805d8:1:00:00
+0:0805d9:3:05:00
+0:0805e4:46:00:FF
+
+whoopee:
+0:0805da:1:00:00
+0:0805db:3:05:00
+0:0805e6:46:00:FF
+
+snowbro2:
+snowbro2b:
+0:1000a0:28:00:45
+
+truxton2:
+tatsujn2:
+0:100300:7c:00:01
+
+;********topspeed.c 
+topspeed:
+topspeedu:
+fullthrl:
+0:400080:6b:00:99
+0:400081:1:45:45
+
+;******toypop.c
+liblrabl:
+0:0867:04:00:00
+0:0874:3B:00:17
+
+toypop:
+0:09b2:50:00:20
+0:0849:3:00:00
+
+;********tsamurai.c
+alphaxz:
+0:c26e:7b:00:2d
+0:c220:3:00:00
+0:E241:1:20:20
+0:E221:1:20:20
+0:E201:1:39:39
+0:E1E1:1:30:30
+0:E1C1:1:30:30
+0:E1A1:1:30:30
+0:E181:1:30:30
+
+m660:
+m660b:
+m660j:
+0:c270:7b:00:2d
+0:c220:3:00:00
+0:E241:1:20:20
+0:E221:1:20:20
+0:E201:1:39:39
+0:E1E1:1:30:30
+0:E1C1:1:30:30
+0:E1A1:1:30:30
+0:E181:1:30:30
+
+;********tumblep.c
+tumblep:
+tumbleb:
+tumbleb2:
+tumblepj:
+tumblepba:
+0:123c10:a0:44:50
+0:123c01:3:00:00
+
+;********tutankhm.c
+tutankhm:
+tutankhms:
+0:88a9:31:03:01
+0:88a6:3:03:40
+
+;*******twin16.c
+fround:
+hpuncher:
+froundl:
+1:40070:4:01:00
+1:40300:50:4a:00
+
+vulcan:
+gradius2:
+gradius2a:
+gradius2b:
+vulcana:
+vulcanb:
+0:600a1:63:22:30
+0:60058:4:00:30
+0:60008:1:1d:1d
+
+fshark:
+fsharkbt:
+skyshark:
+hishouza:
+fsharkbla:
+fnshark:
+skysharka:
+0:3016a:16c:00:01
+0:3038d:1:2d:2d
+0:3038f:1:2d:2d
+0:30391:1:2d:2d
+0:30393:1:03:03
+0:30395:1:00:00
+0:30397:1:00:00
+0:30399:1:00:00
+0:3039b:1:00:00
+
+ktiger:
+0:31280:16c:00:01
+0:3148f:1:2d:2d
+0:31491:1:2d:2d
+0:31493:1:2d:2d
+0:31495:1:03:03
+0:31497:1:00:00
+0:31499:1:00:00
+0:3149b:1:00:00
+0:3149d:1:00:00
+
+twincobr:
+twincobru:
+0:315a2:16c:00:01
+0:317af:1:2d:2d
+0:317b1:1:2d:2d
+0:317b3:1:2d:2d
+0:317b5:1:03:03
+0:317b7:1:00:00
+0:317b9:1:00:00
+0:317bb:1:00:00
+0:317bd:1:00:00
+
+;********ultraman.c
+ultraman:
+0:8ff00:64:01:08
+
+;********vaportra.c
+vaportra:
+vaportru:
+kuhga:
+vaportra3:
+0:fff5d4:78:2e:00
+0:ffc024:4:00:00
+
+;********vendetta.c
+vendetta:
+vendettar:
+vendetta2p:
+vendetta2pu:
+vendetta2pd:
+vendettaj:
+vendetta2peba:
+vendettaz:
+0:2980:28:00:48
+
+;*******vicdual.c
+carnival: ;*note* resetting corrupts the screen not the file
+carnivalc:
+0:e397:3c:00:00
+0:e5a2:9:20:20
+
+digger:
+0:8386:b:53:00
+
+;********vulgus.c
+vulgusa:
+0:EE00:41:00:20
+0:EE47:03:00:00
+
+vulgus:
+vulgusj:
+0:EE00:41:00:2E
+0:EE47:03:00:00
+
+;********wecleman.c
+hotchase:
+hotchasea:
+0:610b0:50:00:0d
+0:60034:4:00:00
+
+;********wiping.c
+wiping:
+0:906f:82:03:54
+
+rugrats:
+0:906f:82:10:54
+
+;********wiz.c
+scion:
+0:c070:50:00:1e
+0:d062:7:10:00
+
+scionc:
+0:c070:50:00:10
+0:d062:7:10:10
+
+stinger:
+stinger2:
+0:c031:1e:00:00
+0:c079:6:00:00
+0:c200:13:1d:23
+
+wiz:
+wizt:
+wizta:
+0:c01e:32:00:43
+
+;********xexex.c
+xexexa:
+xexex:
+xexexj:
+orius:
+0:85000:63:00:1c
+0:80057:3:00:30
+
+xmen:
+xmen2p:
+xmenj:
+xmen2pj:
+xmen6pu:
+xmen6p:
+xmen2pa:
+xmen2pe:
+xmene:
+xmena:
+xmenaa:
+xmen2pu:
+0:113300:168:00:10
+
+;********xybots.c
+xybots:
+0:ffac22:ca:00:a4
+
+;********yard.c
+10yard:
+10yardj:
+vs10yard:
+vs10yardj:
+10yard85:
+vs10yardu:
+0:e600:8a:00:4a
+0:e008:3:00:03
+
+;********yiear.c
+yiear:
+0:5520:8c:00:10
+0:521c:3:00:40
+
+yiear2:
+0:5520:8c:00:10
+0:521c:3:00:70
+
+yieartf:
+0:2d20:8c:00:10
+0:2a1c:3:00:40
+
+;********xaccaria.c
+jackrabt:
+jackrabt2:
+jackrabts:
+0:73ba:48:0a:00
+0:727d:3:00:00
+0:605e:1:00:00
+0:607e:1:00:00
+0:609e:1:ff:ff
+0:60be:1:ff:ff
+0:60de:1:ff:ff
+0:60fe:1:ff:ff
+
+;********zaxxon.c
+zaxxon:
+zaxxon2:
+zaxxonb:
+szaxxon:
+zaxxonj:
+zaxxon3:
+0:6100:7e:90:81
+0:6038:3:00:00
+
+futspy:
+0:6419:3c:00:41
+
+razmataz:
+0:66a4:1e:00:00
+0:6739:3c:25:3e
+
+;Spiders and clones (by GeoMan)
+spiders:
+spiders2:
+0:1c13:3:0:0
+0:1e42:f:0:0
+
+spiders3:
+0:1c12:3:00:00
+0:1e41:f:00:00
+
+;********zerozone.c
+zerozone:
+0:c17cd:77:53:00
+0:c23da:6:00:00
+
+zodiack:
+0:5857:37:00:24
+0:b2df:1:00:00
+0:b2ff:1:00:00
+0:b31f:1:01:01
+0:b33f:1:02:02
+0:b35f:1:08:08
+0:b37f:1:00:00
+0:b39f:1:00:00


### PR DESCRIPTION
highscore.dat is required by MAME in order to support highscore saving for many games. The [mame2003 core does support this function now](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003#high-scores) but does not come with the file.

This PR would make the appropriately-versioned highscore.dat easier to locate for mame2003-libretro users and protect against the chance that this old version of the file disappears in the future.