### PR TITLE
Ignores mame quit function, which was causing a subtle frameskip. Lib…

### DIFF
--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -3853,9 +3853,11 @@ int handle_user_interface(struct mame_bitmap *bitmap)
 
 	/* if the user pressed ESC, stop the emulation */
 	/* but don't quit if the setup menu is on screen */
+#ifndef __LIBRETRO__ // libretro handles quits, so ignore.
 	if (setup_selected == 0 && input_ui_pressed(IPT_UI_CANCEL))
 		return 1;
-
+#endif
+    
 	if (setup_selected == 0 && input_ui_pressed(IPT_UI_CONFIGURE))
 	{
 		setup_selected = -1;


### PR DESCRIPTION
…retro handles this.

See https://retropie.org.uk/forum/topic/8331/lr-mame2003-speeding-up-with-b-button-press for an example. tested with frogger and fix works, and still functions as UI_CANCEL in mame tab menu. 