### PR TITLE
Update Makefile to compile in MIPS3 engine for x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,22 +8,19 @@ ifneq ($(GIT_VERSION)," unknown")
 	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
 
-LIBS := -lm
-
 ifeq ($(platform),)
-	# no platform value passed to make; determine host platform, defaulting to unix
-	platform = unix
-	UNAME_A = $(shell uname -a)
-	ifeq ($(UNAME_A),)
-		platform = windows
-	else ifneq ($(findstring MINGW,$(UNAME_A)),)
-		platform = windows
-	else ifneq ($(findstring Darwin,$(UNAME_A)),)
-		platform = osx
-	else ifneq ($(findstring win,$(UNAME_A)),)
-		platform = windows
-	endif
+platform = unix
+ifeq ($(shell uname -a),)
+   platform = win
+else ifneq ($(findstring MINGW,$(shell uname -a)),)
+   platform = win
+else ifneq ($(findstring Darwin,$(shell uname -a)),)
+   platform = osx
+else ifneq ($(findstring win,$(shell uname -a)),)
+   platform = win
 endif
+endif
+
 
 X86_ASM_68000 = # don't use x86 Assembler 68000 engine by default; set to 1 to enable
 X86_ASM_68020 = # don't use x86 Assembler 68020 engine by default; set to 1 to enable
@@ -32,7 +29,9 @@ X86_MIPS3_DRC = # don't use x86 DRC MIPS3 engine by default;       set to 1 to e
 ifeq ($(ARCH),)
 	# no architecture value passed make; try to determine host platform
 	UNAME_P = $(shell uname -p)
-	ifneq ($(findstring x86_64,$(UNAME_P)),)
+	ifneq ($(findstring powerpc,$(UNAME_P)),)
+		ARCH = ppc
+	else ifneq ($(findstring x86_64,$(UNAME_P)),)
 		# catch "x86_64" first, but no commands for x86_x64 only at this point
 	else ifneq ($(findstring 86,$(UNAME_P)),)
 		ARCH = x86 # if "86" is found now it must be i386 or i686
@@ -43,167 +42,173 @@ ifeq ($(ARCH), x86)
 	X86_MIPS3_DRC = 1
 endif
 
+LIBS := -lm
 
 ifeq ($(platform), unix)
-	TARGET = $(TARGET_NAME)_libretro.so
-	fpic = -fPIC
-	CFLAGS += $(fpic)
-	PLATCFLAGS += -Dstricmp=strcasecmp
-	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+   TARGET = $(TARGET_NAME)_libretro.so
+   fpic = -fPIC
+
+   CFLAGS += $(fpic)
+   PLATCFLAGS += -Dstricmp=strcasecmp
+   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
 
 else ifeq ($(platform), linux-portable)
-	TARGET = $(TARGET_NAME)_libretro.so
-	fpic = -fPIC -nostdlib
-	CFLAGS += $(fpic)
-	PLATCFLAGS += -Dstricmp=strcasecmp
+   TARGET = $(TARGET_NAME)_libretro.so
+   fpic = -fPIC -nostdlib
+
+   CFLAGS += $(fpic)
+   PLATCFLAGS += -Dstricmp=strcasecmp
 	LIBS =
-	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
 
 else ifeq ($(platform), osx)
-	TARGET = $(TARGET_NAME)_libretro.dylib
-	fpic = -fPIC
-	
-	ifeq ($(ARCH),ppc)
-		BIGENDIAN = 1
-		PLATCFLAGS += -D__ppc__ -D__POWERPC__
-	endif
-
-	CFLAGS += $(fpic) -Dstricmp=strcasecmp
-	LDFLAGS += $(fpic) -dynamiclib
-	OSXVER = `sw_vers -productVersion | cut -c 4`
+   TARGET = $(TARGET_NAME)_libretro.dylib
+   fpic = -fPIC
+ifeq ($(ARCH),ppc)
+   BIGENDIAN = 1
+   PLATCFLAGS += -D__ppc__ -D__POWERPC__
+endif
+   CFLAGS += $(fpic) -Dstricmp=strcasecmp
+   LDFLAGS += $(fpic) -dynamiclib
+OSXVER = `sw_vers -productVersion | cut -c 4`
 	fpic += -mmacosx-version-min=10.1
 
+# iOS
 else ifneq (,$(findstring ios,$(platform)))
-	TARGET = $(TARGET_NAME)_libretro_ios.dylib
-	fpic = -fPIC
-	CFLAGS += $(fpic) -Dstricmp=strcasecmp
-	LDFLAGS += $(fpic) -dynamiclib
-	PLATCFLAGS += -D__IOS__
 
-	ifeq ($(IOSSDK),)
-		IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
-	endif
+   TARGET = $(TARGET_NAME)_libretro_ios.dylib
+   fpic = -fPIC
+   CFLAGS += $(fpic) -Dstricmp=strcasecmp
+   LDFLAGS += $(fpic) -dynamiclib
+   PLATCFLAGS += -D__IOS__
 
-	CC = cc -arch armv7 -isysroot $(IOSSDK)
-	LD = cc -arch armv7 -isysroot $(IOSSDK)
-	
-	ifeq ($(platform),ios9)
-		fpic += -miphoneos-version-min=8.0
-		CC += -miphoneos-version-min=8.0
-		LD += -miphoneos-version-min=8.0
-	else
-		fpic += -miphoneos-version-min=5.0
-		CC += -miphoneos-version-min=5.0
-		LD += -miphoneos-version-min=5.0
-	endif
+ifeq ($(IOSSDK),)
+   IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
+endif
+
+   CC = cc -arch armv7 -isysroot $(IOSSDK)
+   LD = cc -arch armv7 -isysroot $(IOSSDK)
+ifeq ($(platform),ios9)
+   fpic += -miphoneos-version-min=8.0
+   CC += -miphoneos-version-min=8.0
+   LD += -miphoneos-version-min=8.0
+else
+   fpic += -miphoneos-version-min=5.0
+   CC += -miphoneos-version-min=5.0
+   LD += -miphoneos-version-min=5.0
+endif
 
 else ifeq ($(platform), ctr)
-	TARGET = $(TARGET_NAME)_libretro_$(platform).a
-	CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
-	CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
-	AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
-	PLATCFLAGS += -DARM11 -D_3DS
-	PLATCFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard -mfpu=vfp
-	PLATCFLAGS += -Wall -mword-relocations
-	PLATCFLAGS += -fomit-frame-pointer -ffast-math
-	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
-	CPU_ARCH := arm
-	STATIC_LINKING = 1
-
+   TARGET = $(TARGET_NAME)_libretro_$(platform).a
+   CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
+   CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
+   AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
+   PLATCFLAGS += -DARM11 -D_3DS
+   PLATCFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard -mfpu=vfp
+   PLATCFLAGS += -Wall -mword-relocations
+   PLATCFLAGS += -fomit-frame-pointer -ffast-math
+   CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
+   CPU_ARCH := arm
+   STATIC_LINKING = 1
 else ifeq ($(platform), rpi2)
-	TARGET = $(TARGET_NAME)_libretro.so
-	fpic = -fPIC
-	CFLAGS += $(fpic)
-	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
-	PLATCFLAGS += -Dstricmp=strcasecmp
-	PLATCFLAGS += -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-	PLATCFLAGS += -fomit-frame-pointer -ffast-math
-	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
-	CPU_ARCH := arm
-	ARM = 1
-
+   TARGET = $(TARGET_NAME)_libretro.so
+   fpic = -fPIC
+   CFLAGS += $(fpic)
+   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+   PLATCFLAGS += -Dstricmp=strcasecmp
+   PLATCFLAGS += -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+   PLATCFLAGS += -fomit-frame-pointer -ffast-math
+   CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
+   CPU_ARCH := arm
+   ARM = 1
 else ifeq ($(platform), rpi3)
-	TARGET = $(TARGET_NAME)_libretro.so
-	fpic = -fPIC
-	CFLAGS += $(fpic)
-	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
-	PLATCFLAGS += -Dstricmp=strcasecmp
-	PLATCFLAGS += -marm -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
-	PLATCFLAGS += -fomit-frame-pointer -ffast-math
-	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
-	CPU_ARCH := arm
-	ARM = 1
-
+   TARGET = $(TARGET_NAME)_libretro.so
+   fpic = -fPIC
+   CFLAGS += $(fpic)
+   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+   PLATCFLAGS += -Dstricmp=strcasecmp
+   PLATCFLAGS += -marm -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
+   PLATCFLAGS += -fomit-frame-pointer -ffast-math
+   CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
+   CPU_ARCH := arm
+   ARM = 1
 else ifeq ($(platform), android-armv7)
-	TARGET = $(TARGET_NAME)_libretro_android.so
-	CFLAGS += -fPIC 
-	PLATCFLAGS += -march=armv7-a -mfloat-abi=softfp -Dstricmp=strcasecmp
-	LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
-	CC = arm-linux-androideabi-gcc
-	AR = arm-linux-androideabi-ar
-	LD = arm-linux-androideabi-gcc
+   TARGET = $(TARGET_NAME)_libretro_android.so
 
+   CFLAGS += -fPIC 
+   PLATCFLAGS += -march=armv7-a -mfloat-abi=softfp -Dstricmp=strcasecmp
+   LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
+
+   CC = arm-linux-androideabi-gcc
+   AR = arm-linux-androideabi-ar
+   LD = arm-linux-androideabi-gcc
 else ifeq ($(platform), qnx)
-	TARGET = $(TARGET_NAME)_libretro_$(platform).so
-	CFLAGS += -fPIC 
-	PLATCFLAGS += -march=armv7-a -Dstricmp=strcasecmp
-	LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
-	CC = qcc -Vgcc_ntoarmv7le
-	AR = qcc -Vgcc_ntoarmv7le
-	LD = QCC -Vgcc_ntoarmv7le
+   TARGET = $(TARGET_NAME)_libretro_$(platform).so
+
+   CFLAGS += -fPIC 
+   PLATCFLAGS += -march=armv7-a -Dstricmp=strcasecmp
+   LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
+
+   CC = qcc -Vgcc_ntoarmv7le
+   AR = qcc -Vgcc_ntoarmv7le
+   LD = QCC -Vgcc_ntoarmv7le
 
 else ifeq ($(platform), wii)
-	TARGET = $(TARGET_NAME)_libretro_$(platform).a
-	BIGENDIAN = 1
-	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
-	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	PLATCFLAGS += -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-	PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
-	STATIC_LINKING = 1
+   TARGET = $(TARGET_NAME)_libretro_$(platform).a
+   BIGENDIAN = 1
+    
+   CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
+   AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
+   PLATCFLAGS += -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+   PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+   STATIC_LINKING = 1
 
 else ifeq ($(platform), wiiu)
-	TARGET = $(TARGET_NAME)_libretro_$(platform).a
-	BIGENDIAN = 1
-	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
-	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	PLATCFLAGS += -DGEKKO -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-	PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
-	STATIC_LINKING = 1
+   TARGET = $(TARGET_NAME)_libretro_$(platform).a
+   BIGENDIAN = 1
+    
+   CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
+   AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
+   PLATCFLAGS += -DGEKKO -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+   PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+   STATIC_LINKING = 1
 
 else ifeq ($(platform), ps3)
-	TARGET = $(TARGET_NAME)_libretro_$(platform).a
-	BIGENDIAN = 1
-	CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
-	AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
-	PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-	STATIC_LINKING = 1
-
+   TARGET = $(TARGET_NAME)_libretro_$(platform).a
+   BIGENDIAN = 1
+    
+   CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
+   AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
+   PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+   STATIC_LINKING = 1
 else ifeq ($(platform), sncps3)
-	TARGET = $(TARGET_NAME)_libretro_ps3.a
-	BIGENDIAN = 1	
-	CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
-	AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
-	PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-	STATIC_LINKING = 1
-	
+   TARGET = $(TARGET_NAME)_libretro_ps3.a
+   BIGENDIAN = 1
+    
+   CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
+   AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
+   PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+   STATIC_LINKING = 1
 else ifeq ($(platform), psl1ght)
-	TARGET = $(TARGET_NAME)_libretro_$(platform).a
-	BIGENDIAN = 1
-	CC = $(PS3DEV)/ppu/bin/ppu-gcc$
-	AR = $(PS3DEV)/ppu/bin/ppu-ar$
-	PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-	STATIC_LINKING = 1
-
+   TARGET = $(TARGET_NAME)_libretro_$(platform).a
+   BIGENDIAN = 1
+    
+   CC = $(PS3DEV)/ppu/bin/ppu-gcc$
+   AR = $(PS3DEV)/ppu/bin/ppu-ar$
+   PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+   STATIC_LINKING = 1
 else ifeq ($(platform), psp1)
 	TARGET = $(TARGET_NAME)_libretro_$(platform).a
+
 	CC = psp-gcc$(EXE_EXT)
 	AR = psp-ar$(EXE_EXT)
 	PLATCFLAGS += -DPSP -Dstricmp=strcasecmp
 	CFLAGS += -G0
-	STATIC_LINKING = 1
+   STATIC_LINKING = 1
 
 else ifeq ($(platform), vita)
 	TARGET = $(TARGET_NAME)_libretro_$(platform).a
+
 	CC = arm-vita-eabi-gcc$(EXE_EXT)
 	AR = arm-vita-eabi-ar$(EXE_EXT)
 	PLATCFLAGS += -DVITA -Dstricmp=strcasecmp
@@ -220,11 +225,13 @@ else ifeq ($(platform), vita)
 	DEBUG = 0
 		
 else ifneq (,$(findstring armv,$(platform)))
-	TARGET = $(TARGET_NAME)_libretro.so
-	CFLAGS += -fPIC
-	PLATCFLAGS += -Dstricmp=strcasecmp
-	LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
+   TARGET = $(TARGET_NAME)_libretro.so
 
+   CFLAGS += -fPIC
+   PLATCFLAGS += -Dstricmp=strcasecmp
+   LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
+
+# GCW0
 else ifeq ($(platform), gcw0)
 	TARGET := $(TARGET_NAME)_libretro.so
 	CC = /opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc-4.9.1
@@ -241,59 +248,62 @@ else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	HAVE_RZLIB := 1
 	STATIC_LINKING := 1
-	PLATCFLAGS += -Dstricmp=strcasecmp
+   PLATCFLAGS += -Dstricmp=strcasecmp
 
+# Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)
 	CC  = cl.exe
 	CXX = cl.exe
 
-	PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin/amd64"):$(PATH)
-	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
-	LIB := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/lib/amd64")
-	INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
+PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin/amd64"):$(PATH)
+PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
+LIB := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/lib/amd64")
+INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
 
-	WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
-	WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
 
-	WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
-	WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
 
-	INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
-	export INCLUDE := $(INCLUDE)
-	export LIB := $(LIB);$(WindowsSdkDir)
-	TARGET := $(TARGET_NAME)_libretro.dll
-	PSS_STYLE :=2
-	LDFLAGS += -DLL
-	LIBS =
 
+INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
+export INCLUDE := $(INCLUDE)
+export LIB := $(LIB);$(WindowsSdkDir)
+TARGET := $(TARGET_NAME)_libretro.dll
+PSS_STYLE :=2
+LDFLAGS += -DLL
+LIBS =
+# Windows MSVC 2010 x86
 else ifeq ($(platform), windows_msvc2010_x86)
 	CC  = cl.exe
 	CXX = cl.exe
 
-	PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin"):$(PATH)
-	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
-	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS100COMNTOOLS)../../VC/lib")
-	INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
+PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin"):$(PATH)
+PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
+LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS100COMNTOOLS)../../VC/lib")
+INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
 
-	WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
-	WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
+WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
+WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
 
-	WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
-	WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
 
-	INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
-	export INCLUDE := $(INCLUDE)
-	export LIB := $(LIB);$(WindowsSdkDir)
-	TARGET := $(TARGET_NAME)_libretro.dll
-	PSS_STYLE :=2
-	LDFLAGS += -DLL
-	LIBS =
 
-else ifeq ($(platform), windows)
-	TARGET := $(TARGET_NAME)_libretro.dll
-	CC = gcc
-	LDFLAGS += -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=link.T
-	CFLAGS += -D__WIN32__ -D__WIN32_LIBRETRO__ -Wno-missing-field-initializers
+INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
+export INCLUDE := $(INCLUDE)
+export LIB := $(LIB);$(WindowsSdkDir)
+TARGET := $(TARGET_NAME)_libretro.dll
+PSS_STYLE :=2
+LDFLAGS += -DLL
+LIBS =
+# Windows
+else
+   TARGET := $(TARGET_NAME)_libretro.dll
+   CC = gcc
+   LDFLAGS += -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=link.T
+   CFLAGS += -D__WIN32__ -D__WIN32_LIBRETRO__ -Wno-missing-field-initializers
 endif
 
 ifeq ($(BIGENDIAN), 1)
@@ -303,27 +313,32 @@ endif
 # use -fsigned-char on ARM to solve potential problems with code written/tested on x86
 # eg on mame2003 audio on rtype leo is wrong without it.
 ifeq ($(ARM), 1)
-	PLATCFLAGS += -fsigned-char
+   PLATCFLAGS += -fsigned-char
 endif
 
 PLATCFLAGS += $(fpic)
+
 RETRO_PROFILE = 0
 CFLAGS += -DRETRO_PROFILE=$(RETRO_PROFILE)
 
 ifneq ($(platform), sncps3)
-	ifeq (,$(findstring msvc,$(platform)))
-		CFLAGS += -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wbad-function-cast -Wcast-align -Waggregate-return -Wshadow -Wstrict-prototypes	-Wformat-security -Wwrite-strings -Wdisabled-optimization
-	endif
+ifeq (,$(findstring msvc,$(platform)))
+CFLAGS += -Wall -Wno-sign-compare -Wunused \
+	-Wpointer-arith -Wbad-function-cast -Wcast-align -Waggregate-return \
+	-Wshadow -Wstrict-prototypes \
+	-Wformat-security -Wwrite-strings \
+	-Wdisabled-optimization
+endif
 endif
 
 ifeq ($(DEBUG), 1)
-	CFLAGS += -O0 -Wall -Wno-unused -g
+   CFLAGS += -O0 -Wall -Wno-unused -g
 else
-	CFLAGS += -O2 -DNDEBUG
+   CFLAGS += -O2 -DNDEBUG
 endif
 
 ifeq (,$(findstring msvc,$(platform)))
-	CFLAGS += -fomit-frame-pointer -fstrict-aliasing
+   CFLAGS += -fomit-frame-pointer -fstrict-aliasing
 endif
 
 # extra options needed *only* for the osd files
@@ -346,7 +361,7 @@ CDEFS = $(DEFS) $(COREDEFS) $(CPUDEFS) $(SOUNDDEFS) $(ASMDEFS) $(DBGDEFS)
 
 OBJECTS := $(SOURCES_C:.c=.o)
 
-OBJOUT	= -o
+OBJOUT   = -o
 LINKOUT  = -o 
 
 ifneq (,$(findstring msvc,$(platform)))
@@ -364,13 +379,13 @@ ifeq ($(STATIC_LINKING),1)
 	$(AR) rcs $@ $(OBJECTS)
 else
 	@echo Linking $@...
-ifeq ($(platform),windows)	
-	@echo Using a temporary file to hold the list of objects, as it can exceed windows shell command limits...
+ifeq ($(platform),win)	
+	# Use a temporary file to hold the list of objects, as it can exceed windows shell command limits
 	$(file >$@.in,$(OBJECTS))
 	$(LD) $(LDFLAGS) $(LINKOUT)$@ @$@.in $(LIBS)
 	@rm $@.in
 else ifneq (,$(findstring msvc,$(platform)))
-	@echo Using a temporary file to hold the list of objects, as it can exceed windows shell command limits...
+	# Use a temporary file to hold the list of objects, as it can exceed windows shell command limits
 	$(file >$@.in,$(OBJECTS))
 	$(LD) $(LDFLAGS) $(LINKOUT)$@ @$@.in $(LIBS)
 	@rm $@.in
@@ -388,8 +403,8 @@ $(OBJ)/%.a:
 	$(AR) cr $@ $^
 
 clean:
-ifeq ($(platform),windows)	
-	@echo Using a temporary file to hold the list of objects, as it can exceed windows shell command limits...
+ifeq ($(platform),win)	
+	# Use a temporary file to hold the list of objects, as it can exceed windows shell command limits
 	$(file >$@.in,$(OBJECTS))
 	rm -f @$@.in $(TARGET)
 	@rm $@.in

--- a/Makefile
+++ b/Makefile
@@ -8,203 +8,202 @@ ifneq ($(GIT_VERSION)," unknown")
 	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
 
-ifeq ($(platform),)
-platform = unix
-ifeq ($(shell uname -a),)
-   platform = win
-else ifneq ($(findstring MINGW,$(shell uname -a)),)
-   platform = win
-else ifneq ($(findstring Darwin,$(shell uname -a)),)
-   platform = osx
-else ifneq ($(findstring win,$(shell uname -a)),)
-   platform = win
-endif
-endif
-
-# system platform
-system_platform = unix
-ifeq ($(shell uname -a),)
-	EXE_EXT = .exe
-	system_platform = win
-else ifneq ($(findstring Darwin,$(shell uname -a)),)
-	system_platform = osx
-ifeq ($(shell uname -p),powerpc)
-	arch = ppc
-else
-	arch = intel
-endif
-else ifneq ($(findstring MINGW,$(shell uname -a)),)
-	system_platform = win
-endif
-
-
 LIBS := -lm
 
-ifeq ($(platform), unix)
-   TARGET = $(TARGET_NAME)_libretro.so
-   fpic = -fPIC
+ifeq ($(platform),)
+	# no platform value passed to make; determine host platform, defaulting to unix
+	platform = unix
+	UNAME_A = $(shell uname -a)
+	ifeq ($(UNAME_A),)
+		platform = windows
+	else ifneq ($(findstring MINGW,$(UNAME_A)),)
+		platform = windows
+	else ifneq ($(findstring Darwin,$(UNAME_A)),)
+		platform = osx
+	else ifneq ($(findstring win,$(UNAME_A)),)
+		platform = windows
+	endif
+endif
 
-   CFLAGS += $(fpic)
-   PLATCFLAGS += -Dstricmp=strcasecmp
-   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+X86_ASM_68000 = # don't use x86 Assembler 68000 engine by default; set to 1 to enable
+X86_ASM_68020 = # don't use x86 Assembler 68020 engine by default; set to 1 to enable
+X86_MIPS3_DRC = # don't use x86 DRC MIPS3 engine by default;       set to 1 to enable
+
+ifeq ($(ARCH),)
+	# no architecture value passed make; try to determine host platform
+	UNAME_P = $(shell uname -p)
+	ifneq ($(findstring x86_64,$(UNAME_P)),)
+		# catch "x86_64" first, but no commands for x86_x64 only at this point
+	else ifneq ($(findstring 86,$(UNAME_P)),)
+		ARCH = x86 # if "86" is found now it must be i386 or i686
+	endif
+endif
+
+ifeq ($(ARCH), x86)
+	X86_MIPS3_DRC = 1
+endif
+
+
+ifeq ($(platform), unix)
+	TARGET = $(TARGET_NAME)_libretro.so
+	fpic = -fPIC
+	CFLAGS += $(fpic)
+	PLATCFLAGS += -Dstricmp=strcasecmp
+	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
 
 else ifeq ($(platform), linux-portable)
-   TARGET = $(TARGET_NAME)_libretro.so
-   fpic = -fPIC -nostdlib
-
-   CFLAGS += $(fpic)
-   PLATCFLAGS += -Dstricmp=strcasecmp
+	TARGET = $(TARGET_NAME)_libretro.so
+	fpic = -fPIC -nostdlib
+	CFLAGS += $(fpic)
+	PLATCFLAGS += -Dstricmp=strcasecmp
 	LIBS =
-   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
 
 else ifeq ($(platform), osx)
-   TARGET = $(TARGET_NAME)_libretro.dylib
-   fpic = -fPIC
-ifeq ($(arch),ppc)
-   BIGENDIAN = 1
-   PLATCFLAGS += -D__ppc__ -D__POWERPC__
-endif
-   CFLAGS += $(fpic) -Dstricmp=strcasecmp
-   LDFLAGS += $(fpic) -dynamiclib
-OSXVER = `sw_vers -productVersion | cut -c 4`
+	TARGET = $(TARGET_NAME)_libretro.dylib
+	fpic = -fPIC
+	
+	ifeq ($(ARCH),ppc)
+		BIGENDIAN = 1
+		PLATCFLAGS += -D__ppc__ -D__POWERPC__
+	endif
+
+	CFLAGS += $(fpic) -Dstricmp=strcasecmp
+	LDFLAGS += $(fpic) -dynamiclib
+	OSXVER = `sw_vers -productVersion | cut -c 4`
 	fpic += -mmacosx-version-min=10.1
 
-# iOS
 else ifneq (,$(findstring ios,$(platform)))
+	TARGET = $(TARGET_NAME)_libretro_ios.dylib
+	fpic = -fPIC
+	CFLAGS += $(fpic) -Dstricmp=strcasecmp
+	LDFLAGS += $(fpic) -dynamiclib
+	PLATCFLAGS += -D__IOS__
 
-   TARGET = $(TARGET_NAME)_libretro_ios.dylib
-   fpic = -fPIC
-   CFLAGS += $(fpic) -Dstricmp=strcasecmp
-   LDFLAGS += $(fpic) -dynamiclib
-   PLATCFLAGS += -D__IOS__
+	ifeq ($(IOSSDK),)
+		IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
+	endif
 
-ifeq ($(IOSSDK),)
-   IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
-endif
-
-   CC = cc -arch armv7 -isysroot $(IOSSDK)
-   LD = cc -arch armv7 -isysroot $(IOSSDK)
-ifeq ($(platform),ios9)
-   fpic += -miphoneos-version-min=8.0
-   CC += -miphoneos-version-min=8.0
-   LD += -miphoneos-version-min=8.0
-else
-   fpic += -miphoneos-version-min=5.0
-   CC += -miphoneos-version-min=5.0
-   LD += -miphoneos-version-min=5.0
-endif
+	CC = cc -arch armv7 -isysroot $(IOSSDK)
+	LD = cc -arch armv7 -isysroot $(IOSSDK)
+	
+	ifeq ($(platform),ios9)
+		fpic += -miphoneos-version-min=8.0
+		CC += -miphoneos-version-min=8.0
+		LD += -miphoneos-version-min=8.0
+	else
+		fpic += -miphoneos-version-min=5.0
+		CC += -miphoneos-version-min=5.0
+		LD += -miphoneos-version-min=5.0
+	endif
 
 else ifeq ($(platform), ctr)
-   TARGET = $(TARGET_NAME)_libretro_$(platform).a
-   CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
-   CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
-   AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
-   PLATCFLAGS += -DARM11 -D_3DS
-   PLATCFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard -mfpu=vfp
-   PLATCFLAGS += -Wall -mword-relocations
-   PLATCFLAGS += -fomit-frame-pointer -ffast-math
-   CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
-   CPU_ARCH := arm
-   STATIC_LINKING = 1
+	TARGET = $(TARGET_NAME)_libretro_$(platform).a
+	CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
+	CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
+	AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
+	PLATCFLAGS += -DARM11 -D_3DS
+	PLATCFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard -mfpu=vfp
+	PLATCFLAGS += -Wall -mword-relocations
+	PLATCFLAGS += -fomit-frame-pointer -ffast-math
+	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
+	CPU_ARCH := arm
+	STATIC_LINKING = 1
+
 else ifeq ($(platform), rpi2)
-   TARGET = $(TARGET_NAME)_libretro.so
-   fpic = -fPIC
-   CFLAGS += $(fpic)
-   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
-   PLATCFLAGS += -Dstricmp=strcasecmp
-   PLATCFLAGS += -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-   PLATCFLAGS += -fomit-frame-pointer -ffast-math
-   CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
-   CPU_ARCH := arm
-   ARM = 1
+	TARGET = $(TARGET_NAME)_libretro.so
+	fpic = -fPIC
+	CFLAGS += $(fpic)
+	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+	PLATCFLAGS += -Dstricmp=strcasecmp
+	PLATCFLAGS += -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+	PLATCFLAGS += -fomit-frame-pointer -ffast-math
+	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
+	CPU_ARCH := arm
+	ARM = 1
+
 else ifeq ($(platform), rpi3)
-   TARGET = $(TARGET_NAME)_libretro.so
-   fpic = -fPIC
-   CFLAGS += $(fpic)
-   LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
-   PLATCFLAGS += -Dstricmp=strcasecmp
-   PLATCFLAGS += -marm -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
-   PLATCFLAGS += -fomit-frame-pointer -ffast-math
-   CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
-   CPU_ARCH := arm
-   ARM = 1
+	TARGET = $(TARGET_NAME)_libretro.so
+	fpic = -fPIC
+	CFLAGS += $(fpic)
+	LDFLAGS += $(fpic) -shared -Wl,--version-script=link.T
+	PLATCFLAGS += -Dstricmp=strcasecmp
+	PLATCFLAGS += -marm -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
+	PLATCFLAGS += -fomit-frame-pointer -ffast-math
+	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
+	CPU_ARCH := arm
+	ARM = 1
+
 else ifeq ($(platform), android-armv7)
-   TARGET = $(TARGET_NAME)_libretro_android.so
+	TARGET = $(TARGET_NAME)_libretro_android.so
+	CFLAGS += -fPIC 
+	PLATCFLAGS += -march=armv7-a -mfloat-abi=softfp -Dstricmp=strcasecmp
+	LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
+	CC = arm-linux-androideabi-gcc
+	AR = arm-linux-androideabi-ar
+	LD = arm-linux-androideabi-gcc
 
-   CFLAGS += -fPIC 
-   PLATCFLAGS += -march=armv7-a -mfloat-abi=softfp -Dstricmp=strcasecmp
-   LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
-
-   CC = arm-linux-androideabi-gcc
-   AR = arm-linux-androideabi-ar
-   LD = arm-linux-androideabi-gcc
 else ifeq ($(platform), qnx)
-   TARGET = $(TARGET_NAME)_libretro_$(platform).so
-
-   CFLAGS += -fPIC 
-   PLATCFLAGS += -march=armv7-a -Dstricmp=strcasecmp
-   LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
-
-   CC = qcc -Vgcc_ntoarmv7le
-   AR = qcc -Vgcc_ntoarmv7le
-   LD = QCC -Vgcc_ntoarmv7le
+	TARGET = $(TARGET_NAME)_libretro_$(platform).so
+	CFLAGS += -fPIC 
+	PLATCFLAGS += -march=armv7-a -Dstricmp=strcasecmp
+	LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
+	CC = qcc -Vgcc_ntoarmv7le
+	AR = qcc -Vgcc_ntoarmv7le
+	LD = QCC -Vgcc_ntoarmv7le
 
 else ifeq ($(platform), wii)
-   TARGET = $(TARGET_NAME)_libretro_$(platform).a
-   BIGENDIAN = 1
-    
-   CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
-   AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   PLATCFLAGS += -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-   PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
-   STATIC_LINKING = 1
+	TARGET = $(TARGET_NAME)_libretro_$(platform).a
+	BIGENDIAN = 1
+	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
+	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
+	PLATCFLAGS += -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+	PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+	STATIC_LINKING = 1
 
 else ifeq ($(platform), wiiu)
-   TARGET = $(TARGET_NAME)_libretro_$(platform).a
-   BIGENDIAN = 1
-    
-   CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
-   AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   PLATCFLAGS += -DGEKKO -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-   PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
-   STATIC_LINKING = 1
+	TARGET = $(TARGET_NAME)_libretro_$(platform).a
+	BIGENDIAN = 1
+	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
+	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
+	PLATCFLAGS += -DGEKKO -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+	PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+	STATIC_LINKING = 1
 
 else ifeq ($(platform), ps3)
-   TARGET = $(TARGET_NAME)_libretro_$(platform).a
-   BIGENDIAN = 1
-    
-   CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
-   AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
-   PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-   STATIC_LINKING = 1
+	TARGET = $(TARGET_NAME)_libretro_$(platform).a
+	BIGENDIAN = 1
+	CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
+	AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
+	PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+	STATIC_LINKING = 1
+
 else ifeq ($(platform), sncps3)
-   TARGET = $(TARGET_NAME)_libretro_ps3.a
-   BIGENDIAN = 1
-    
-   CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
-   AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
-   PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-   STATIC_LINKING = 1
+	TARGET = $(TARGET_NAME)_libretro_ps3.a
+	BIGENDIAN = 1	
+	CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
+	AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
+	PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+	STATIC_LINKING = 1
+	
 else ifeq ($(platform), psl1ght)
-   TARGET = $(TARGET_NAME)_libretro_$(platform).a
-   BIGENDIAN = 1
-    
-   CC = $(PS3DEV)/ppu/bin/ppu-gcc$
-   AR = $(PS3DEV)/ppu/bin/ppu-ar$
-   PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
-   STATIC_LINKING = 1
+	TARGET = $(TARGET_NAME)_libretro_$(platform).a
+	BIGENDIAN = 1
+	CC = $(PS3DEV)/ppu/bin/ppu-gcc$
+	AR = $(PS3DEV)/ppu/bin/ppu-ar$
+	PLATCFLAGS += -D__CELLOS_LV2__ -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+	STATIC_LINKING = 1
+
 else ifeq ($(platform), psp1)
 	TARGET = $(TARGET_NAME)_libretro_$(platform).a
-
 	CC = psp-gcc$(EXE_EXT)
 	AR = psp-ar$(EXE_EXT)
 	PLATCFLAGS += -DPSP -Dstricmp=strcasecmp
 	CFLAGS += -G0
-   STATIC_LINKING = 1
+	STATIC_LINKING = 1
 
 else ifeq ($(platform), vita)
 	TARGET = $(TARGET_NAME)_libretro_$(platform).a
-
 	CC = arm-vita-eabi-gcc$(EXE_EXT)
 	AR = arm-vita-eabi-ar$(EXE_EXT)
 	PLATCFLAGS += -DVITA -Dstricmp=strcasecmp
@@ -221,13 +220,11 @@ else ifeq ($(platform), vita)
 	DEBUG = 0
 		
 else ifneq (,$(findstring armv,$(platform)))
-   TARGET = $(TARGET_NAME)_libretro.so
+	TARGET = $(TARGET_NAME)_libretro.so
+	CFLAGS += -fPIC
+	PLATCFLAGS += -Dstricmp=strcasecmp
+	LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
 
-   CFLAGS += -fPIC
-   PLATCFLAGS += -Dstricmp=strcasecmp
-   LDFLAGS += -fPIC -shared -Wl,--version-script=link.T
-
-# GCW0
 else ifeq ($(platform), gcw0)
 	TARGET := $(TARGET_NAME)_libretro.so
 	CC = /opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc-4.9.1
@@ -244,62 +241,59 @@ else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	HAVE_RZLIB := 1
 	STATIC_LINKING := 1
-   PLATCFLAGS += -Dstricmp=strcasecmp
+	PLATCFLAGS += -Dstricmp=strcasecmp
 
-# Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)
 	CC  = cl.exe
 	CXX = cl.exe
 
-PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin/amd64"):$(PATH)
-PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
-LIB := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/lib/amd64")
-INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
+	PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin/amd64"):$(PATH)
+	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
+	LIB := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/lib/amd64")
+	INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
 
-WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
-WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+	WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+	WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
 
-WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
-WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+	WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+	WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
 
+	INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
+	export INCLUDE := $(INCLUDE)
+	export LIB := $(LIB);$(WindowsSdkDir)
+	TARGET := $(TARGET_NAME)_libretro.dll
+	PSS_STYLE :=2
+	LDFLAGS += -DLL
+	LIBS =
 
-INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
-export INCLUDE := $(INCLUDE)
-export LIB := $(LIB);$(WindowsSdkDir)
-TARGET := $(TARGET_NAME)_libretro.dll
-PSS_STYLE :=2
-LDFLAGS += -DLL
-LIBS =
-# Windows MSVC 2010 x86
 else ifeq ($(platform), windows_msvc2010_x86)
 	CC  = cl.exe
 	CXX = cl.exe
 
-PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin"):$(PATH)
-PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
-LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS100COMNTOOLS)../../VC/lib")
-INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
+	PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin"):$(PATH)
+	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
+	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS100COMNTOOLS)../../VC/lib")
+	INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
 
-WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
-WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
+	WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
+	WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
 
-WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
-WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+	WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+	WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
 
+	INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
+	export INCLUDE := $(INCLUDE)
+	export LIB := $(LIB);$(WindowsSdkDir)
+	TARGET := $(TARGET_NAME)_libretro.dll
+	PSS_STYLE :=2
+	LDFLAGS += -DLL
+	LIBS =
 
-INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
-export INCLUDE := $(INCLUDE)
-export LIB := $(LIB);$(WindowsSdkDir)
-TARGET := $(TARGET_NAME)_libretro.dll
-PSS_STYLE :=2
-LDFLAGS += -DLL
-LIBS =
-# Windows
-else
-   TARGET := $(TARGET_NAME)_libretro.dll
-   CC = gcc
-   LDFLAGS += -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=link.T
-   CFLAGS += -D__WIN32__ -D__WIN32_LIBRETRO__ -Wno-missing-field-initializers
+else ifeq ($(platform), windows)
+	TARGET := $(TARGET_NAME)_libretro.dll
+	CC = gcc
+	LDFLAGS += -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=link.T
+	CFLAGS += -D__WIN32__ -D__WIN32_LIBRETRO__ -Wno-missing-field-initializers
 endif
 
 ifeq ($(BIGENDIAN), 1)
@@ -309,41 +303,27 @@ endif
 # use -fsigned-char on ARM to solve potential problems with code written/tested on x86
 # eg on mame2003 audio on rtype leo is wrong without it.
 ifeq ($(ARM), 1)
-   PLATCFLAGS += -fsigned-char
+	PLATCFLAGS += -fsigned-char
 endif
 
 PLATCFLAGS += $(fpic)
-
-# uncomment next line to use Assembler 68000 engine
-# X86_ASM_68000 = 1
-
-# uncomment next line to use Assembler 68020 engine
-# X86_ASM_68020 = 1
-
-# uncomment next line to use DRC MIPS3 engine
-# X86_MIPS3_DRC = 1
-
 RETRO_PROFILE = 0
 CFLAGS += -DRETRO_PROFILE=$(RETRO_PROFILE)
 
 ifneq ($(platform), sncps3)
-ifeq (,$(findstring msvc,$(platform)))
-CFLAGS += -Wall -Wno-sign-compare -Wunused \
-	-Wpointer-arith -Wbad-function-cast -Wcast-align -Waggregate-return \
-	-Wshadow -Wstrict-prototypes \
-	-Wformat-security -Wwrite-strings \
-	-Wdisabled-optimization
-endif
+	ifeq (,$(findstring msvc,$(platform)))
+		CFLAGS += -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wbad-function-cast -Wcast-align -Waggregate-return -Wshadow -Wstrict-prototypes	-Wformat-security -Wwrite-strings -Wdisabled-optimization
+	endif
 endif
 
 ifeq ($(DEBUG), 1)
-   CFLAGS += -O0 -Wall -Wno-unused -g
+	CFLAGS += -O0 -Wall -Wno-unused -g
 else
-   CFLAGS += -O2 -DNDEBUG
+	CFLAGS += -O2 -DNDEBUG
 endif
 
 ifeq (,$(findstring msvc,$(platform)))
-   CFLAGS += -fomit-frame-pointer -fstrict-aliasing
+	CFLAGS += -fomit-frame-pointer -fstrict-aliasing
 endif
 
 # extra options needed *only* for the osd files
@@ -366,7 +346,7 @@ CDEFS = $(DEFS) $(COREDEFS) $(CPUDEFS) $(SOUNDDEFS) $(ASMDEFS) $(DBGDEFS)
 
 OBJECTS := $(SOURCES_C:.c=.o)
 
-OBJOUT   = -o
+OBJOUT	= -o
 LINKOUT  = -o 
 
 ifneq (,$(findstring msvc,$(platform)))
@@ -384,13 +364,13 @@ ifeq ($(STATIC_LINKING),1)
 	$(AR) rcs $@ $(OBJECTS)
 else
 	@echo Linking $@...
-ifeq ($(platform),win)	
-	# Use a temporary file to hold the list of objects, as it can exceed windows shell command limits
+ifeq ($(platform),windows)	
+	@echo Using a temporary file to hold the list of objects, as it can exceed windows shell command limits...
 	$(file >$@.in,$(OBJECTS))
 	$(LD) $(LDFLAGS) $(LINKOUT)$@ @$@.in $(LIBS)
 	@rm $@.in
 else ifneq (,$(findstring msvc,$(platform)))
-	# Use a temporary file to hold the list of objects, as it can exceed windows shell command limits
+	@echo Using a temporary file to hold the list of objects, as it can exceed windows shell command limits...
 	$(file >$@.in,$(OBJECTS))
 	$(LD) $(LDFLAGS) $(LINKOUT)$@ @$@.in $(LIBS)
 	@rm $@.in
@@ -408,8 +388,8 @@ $(OBJ)/%.a:
 	$(AR) cr $@ $^
 
 clean:
-ifeq ($(platform),win)	
-	# Use a temporary file to hold the list of objects, as it can exceed windows shell command limits
+ifeq ($(platform),windows)	
+	@echo Using a temporary file to hold the list of objects, as it can exceed windows shell command limits...
 	$(file >$@.in,$(OBJECTS))
 	rm -f @$@.in $(TARGET)
 	@rm $@.in


### PR DESCRIPTION
This PR has makes two tweaks:

* Add logic to compile MIPS3 engine when ARCH = x86 as passed to make. ARCH = x86 is already specified in all but one x86 buildbot recipe
* If ARCH is not specified, try to detect if those host system is x86 and compile in support

In order for generic Linux x86 to benefit from this, the corresponding buildbot .conf will need an update in libretro-super.

I'm hoping for code review. @dankcushions I'd be glad of any input you have.

I've tested this makefile in Windows where it seems to be working fine, despite some other issues I'm having getting my MAME 2003 build environment set up under MYSYS2.  Any hints about that are also welcome.