### PR TITLE
remove outdated todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ MAME 2003 also supports one or two spinners/dials via the "Share 2 player dial c
  
  
 ## Development todo:
-* Make sure all of the mkdir commands in makefile complete before any compiling starts.
 * Input Descriptors (for use in Core Input Remapping).
 * Expose all MAME options as Core Options (including various vector game-specific options)
 * Artwork support.


### PR DESCRIPTION
There are no mkdir commands in the MAME 2003 Makefile at this point. Seems like this todo is no longer relevant.