### PR TITLE
Temptative fix for DCS sound games issue.

### DIFF
--- a/src/libretro/osd.c
+++ b/src/libretro/osd.c
@@ -151,10 +151,12 @@ Sound
 ******************************************************************************/
 
 static bool stereo;
+static float delta_samples;
 
 int osd_start_audio_stream(int aStereo)
 {
 	stereo = (aStereo != 0);
+	delta_samples = 0.0f;
 	return (Machine->sample_rate / Machine->drv->frames_per_second);
 }
 
@@ -174,7 +176,16 @@ int osd_update_audio_stream(INT16 *buffer)
 		}
 	}
 
-	return (Machine->sample_rate / Machine->drv->frames_per_second);
+	// Take care of fractional part
+	delta_samples += (Machine->sample_rate / Machine->drv->frames_per_second) - samplerate_buffer_size;
+	if (delta_samples >= 1.0f)
+	{
+		int integer_delta = (int)delta_samples;
+		samplerate_buffer_size += integer_delta;
+		delta_samples -= integer_delta;
+	}
+
+	return samplerate_buffer_size;
 }
 
 void osd_stop_audio_stream(void)


### PR DESCRIPTION
OSD does not take into account fractional part of sample_rate / fps calculation.
This can lead to accumulating "missed" samples" causing DCS internal buffer overflow and potentially other audio issues in other MAME drivers.

This PR only touches OSD audio code so this should also improve accuracy of audio emulation of the whole mame2003-libretro core.

I have tested around 10 different MAME games without any other side-effect or regression.