### PR TITLE
 Add link to RetroArch documentation/give credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ MAME 2003 also supports one or two spinners/dials via the "Share 2 player dial c
 
 ## Additional configuration information:
  * Official RetroArch documentation for the mame2003-libretro core are published at [buildbot.libretro.com/docs](https://buildbot.libretro.com/docs/). They can be [edited and improved by users via github.com](https://github.com/libretro/docs/blob/master/docs/library/mame2003.md).
- * The RetrArch documentation owes much to RetroPie's [detailed MAME 2003 configuration wiki](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003) which can be adapted for use in other environments.
+ * The RetroArch documentation owes much to RetroPie's [detailed MAME 2003 configuration wiki](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003) which can be adapted for use in other environments.
  
  
 ## Development todo:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ MAME 2003 also supports one or two spinners/dials via the "Share 2 player dial c
   Enable if rotating display for vertically oriented games (Pac-Man, Galaga, etc). Requires `video_allow_rotate = "false"` cfg setting in RetroArch.
 
 ## Additional configuration information:
- * RetroPie publishes [a detailed MAME 2003 configuration wiki](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003) which can be adapted for use in other environments.
+ * Official RetroArch documentation for the mame2003-libretro core are published at [buildbot.libretro.com/docs](https://buildbot.libretro.com/docs/). They can be [edited and improved by users via github.com](https://github.com/libretro/docs/blob/master/docs/library/mame2003.md).
+ * The RetrArch documentation owes much to RetroPie's [detailed MAME 2003 configuration wiki](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003) which can be adapted for use in other environments.
  
  
 ## Development todo:


### PR DESCRIPTION
Adds a link to the new RetroArch documentation. @dankcushions and others might notice that there are some pretty familiar passages: the RetroPie docs were invaluable sources. I've tried to make sure to give some credit here.