### PR TITLE
Fix build PS3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,7 +402,7 @@ all:	$(TARGET)
 $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING),1)
 	@echo Archiving $@...
-ifeq ($(platform), win)
+ifeq ($(platform), ps3)
 	$(AR) rcs $@ $(foreach OBJECTS,$(OBJECTS),$(NEWLINE) $(AR) q $@ $(OBJECTS))
 else
 	$(AR) rcs $@ $(OBJECTS)
@@ -433,8 +433,9 @@ ifeq ($(platform), win)
 	$(file >$@.in,$(OBJECTS))
 	rm -f @$@.in $(TARGET)
 	@rm $@.in
-else
+else ifeq ($(platform), ps3)
 	find . -name "*.o" -type f -delete
 	rm -f *.a
+else
 	rm -f $(OBJECTS) $(TARGET)
 endif


### PR DESCRIPTION
In my previous pull I wrote the issue came from windows but it was for
the platform ps3 compiled in windows (mingw32).
Anyway, I think this time I fixed it in a more proper way, It won't
break other platforms compilation.