### PR TITLE
fixed- update game playability information (romsets starting with #s)

### DIFF
--- a/metadata/catver.ini
+++ b/metadata/catver.ini
@@ -14,9 +14,9 @@
 1944=Shooter / Flying Vertical
 1944j=Shooter / Flying Vertical
 19xx=Shooter / Flying Vertical
-19xxa=Shooter / Flying Vertical
+19xxa=Unplayable
 19xxh=Shooter / Flying Vertical
-19xxj=Shooter / Flying Vertical
+19xxj=Unplayable
 19xxjr1=Shooter / Flying Vertical
 2020bb=Sports / Baseball
 2020bbh=Sports / Baseball
@@ -33,7 +33,7 @@
 4dwarrio=Shooter / Flying Horizontal
 4enraya=Tabletop
 4in1=Multiplay
-4in1boot=Unplayable
+4in1boot=Multiplay
 600=Maze
 64streej=Beat Em Up
 64street=Beat Em Up
@@ -54,9 +54,9 @@
 8bpm=Sports / Pool
 99lstwar=Shooter / Gallery
 99lstwra=Shooter / Gallery
-9ballsh2=Sports / Pool
-9ballsh3=Sports / Pool
-9ballsht=Sports / Pool
+9ballsh2=Unplayable
+9ballsh3=Unplayable
+9ballsht=Unplayable
 a51mxr3k=Lightgun
 aafb=Sports / Football Amer.
 aafbb=Sports / Football Amer.

--- a/src/drivers/snowbros.c
+++ b/src/drivers/snowbros.c
@@ -1268,10 +1268,10 @@ GAME( 1990, wintbob,  snowbros, wintbob,  snowbros, 0, ROT0, "bootleg", "The Win
 /* SemiCom Games */
 GAME( 1995, hyperpac, 0,        hyperpac, hyperpac, hyperpac, ROT0, "SemiCom", "Hyper Pacman" )
 GAME( 1995, hyperpcb, hyperpac, hyperpac, hyperpac, 0,        ROT0, "bootleg", "Hyper Pacman (bootleg)" )
-GAME (1996, cookbib2, 0,        hyperpac, cookbib2, cookbib2, ROT0, "SemiCom", "Cookie and Bibi 2" ) // sound cuts out in later levels? (investigate)
+GAME(1996, cookbib2, 0,        hyperpac, cookbib2, cookbib2, ROT0, "SemiCom", "Cookie and Bibi 2" ) // sound cuts out in later levels? (investigate)
+/* bad dump */
+GAME(199?, 4in1boot, 0,        _4in1,    snowbros, 4in1boot, ROT0, "bootleg", "4-in-1 bootleg" ) // gfx rom is half the size it should be, pacman 2 and snowbros are playable tho
 /* the following don't work, they either point the interrupts at an area of ram probably shared by
    some kind of mcu which puts 68k code there, or jump to the area in the interrupts */
 GAMEX(199?, moremorp, 0,        hyperpac, hyperpac, 0,        ROT0, "SemiCom", "More More +", GAME_UNEMULATED_PROTECTION | GAME_NOT_WORKING )
 GAMEX(1997, 3in1semi, 0,        hyperpac, hyperpac, 0,        ROT0, "SemiCom", "3-in-1 (SemiCom)", GAME_UNEMULATED_PROTECTION | GAME_NOT_WORKING )
-/* bad dump */
-GAMEX(199?, 4in1boot, 0,        _4in1,    snowbros, 4in1boot, ROT0, "bootleg", "4-in-1 bootleg", GAME_NOT_WORKING ) // gfx rom is half the size it should be, pacman 2 and snowbros are playable tho


### PR DESCRIPTION
This PR is based on a current fork to clear up the conflict in my earlier PR.

This PR corrects some "playability" information based on my testing with the original MAME 0.78 executable. I'm also cross referencing [the RetroPie crowdsource testing of MAME 2003 romsets](https://docs.google.com/spreadsheets/d/1LP1MELCvcxu7TfiowF_0ZuvRVEMqlfQyTVetnOJvuJc/edit?usp=sharing).

I'm contemplating a process to help check and correct this information for all of the games, but for now here is at least the first section, hand-corrected.