### PR TITLE
Sega Core Revert

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -2769,7 +2769,6 @@ DokiDoki Penguin Land *not confirmed
 	DRIVER( shdancbl )	/* (c) 1989 (but bootleg) */
 	DRIVER( shdancer )	/* (c) 1989 */
 	DRIVER( shdancrj )	/* (c) 1989 */
-	DRIVER( shdancrb )	/* (c) 1989 */
 	DRIVER( shinobi )	/* (c) 1987 */
 	DRIVER( shinobl )	/* (c) 1987 (but bootleg) */
 	DRIVER( sonicbom )	/* (c) 1987 */

--- a/src/driver.c
+++ b/src/driver.c
@@ -1792,6 +1792,7 @@ const struct GameDriver *test_drivers[] =
 	DRIVER( whoopee )	/* TP-025 */
 	DRIVER( pipibibi )	/* (c) 1991 Ryouta Kikaku (bootleg?) */
 	DRIVER( fixeight )	/* TP-026 (c) 1992 + Taito license */
+	DRIVER( fixeighb )	/* TP-026 */
 	DRIVER( vfive )		/* TP-027 (c) 1993 Toaplan (Japan) */
 	DRIVER( grindstm )	/* TP-027 (c) 1993 Toaplan + Unite Trading license (Korea) */
 	DRIVER( grindsta )	/* TP-027 (c) 1993 Toaplan + Unite Trading license (Korea) */


### PR DESCRIPTION
Extra version of Shadow Dancer no longer supported