### PR TITLE
Improve sample sounds in Donkey Kong and Donkey Kong JR

### DIFF
--- a/src/drivers/dkong.c
+++ b/src/drivers/dkong.c
@@ -1420,9 +1420,11 @@ static struct DACinterface dkong_dac_interface =
 static const char *dkong_sample_names[] =
 {
 	"*dkong",
-	"effect00.wav",
-	"effect01.wav",
-	"effect02.wav",
+	"run01.wav",
+	"run02.wav",
+	"run03.wav",
+	"jump.wav",
+	"dkstomp.wav",
 	0	/* end of array */
 };
 
@@ -1432,11 +1434,15 @@ static const char *dkongjr_sample_names[] =
 	"jump.wav",
 	"land.wav",
 	"roar.wav",
-	"climb.wav",   /* HC */
-	"death.wav",  /* HC */
-	"drop.wav",  /* HC */
-	"walk.wav", /* HC */
-	"snapjaw.wav",  /* HC */
+	"climb0.wav",
+	"climb1.wav",
+	"climb2.wav",
+	"death.wav",
+	"drop.wav",
+	"walk0.wav",
+	"walk1.wav",
+	"walk2.wav",
+	"snapjaw.wav",
 	0	/* end of array */
 };
 


### PR DESCRIPTION
0.86u3: Donkey Kong sample improvements [Peter Rittwage, Derrick Renaud]. Added samples (run01, run02, run03, jump and dkstomp.wav).
0.86u3: Peter Rittwage and Derrick Renaud replaced the old climb and walk sample with three different samples. Replaced climb- and walk.wav with climb0, climb1 and climb2.wav and walk0, walk1 and walk2.wav.

Code via BritneysPAIRS