### PR TITLE
Make the Williams speedhack a Core option so it can be disabled for g…

### DIFF
--- a/src/driver.h
+++ b/src/driver.h
@@ -560,5 +560,6 @@ extern const struct GameDriver *drivers[];
 extern const struct GameDriver *test_drivers[];
 
 extern unsigned activate_dcs_speedhack;
+extern unsigned activate_williams_speedhack;
 
 #endif

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -23,6 +23,8 @@ unsigned activate_dcs_speedhack = 1;
 unsigned activate_dcs_speedhack = 0;
 #endif
 
+unsigned activate_williams_speedhack = 0;
+
 struct retro_perf_callback perf_cb;
 
 retro_log_printf_t log_cb = NULL;
@@ -48,6 +50,7 @@ void retro_set_environment(retro_environment_t cb)
          "MK2/MK3 DCS Speedhack; enabled|disabled"
 #endif
       },
+      { "mame2003-williams-speedhack", "Williams Speedhack; enabled|disabled" },
       { "mame2003-skip_disclaimer", "Skip Disclaimer; enabled|disabled" },
       { "mame2003-skip_warnings", "Skip Warnings; disabled|enabled" },
       { "mame2003-samples", "Samples; enabled|disabled" },
@@ -205,6 +208,19 @@ static void update_variables(void)
    else
       activate_dcs_speedhack = 0;
    
+   var.value = NULL;
+   var.key = "mame2003-williams-speedhack";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || var.value)
+   {
+      if(strcmp(var.value, "enabled") == 0)
+         activate_williams_speedhack = 1;
+      else
+         activate_williams_speedhack = 0;
+   }
+   else
+      activate_williams_speedhack = 0;
+
    var.value = NULL;
    var.key = "mame2003-skip_disclaimer";
    

--- a/src/sndhrdw/williams_sndhrdw.c
+++ b/src/sndhrdw/williams_sndhrdw.c
@@ -34,8 +34,9 @@
 	COMPILER SWITCHES
 ****************************************************************************/
 
-#define DISABLE_FIRQ_SPEEDUP		0
-#define DISABLE_LOOP_CATCHERS		0
+/* Replaced by variables so they can be enabled/disabled via core options */
+//  #define DISABLE_FIRQ_SPEEDUP		0
+//  #define DISABLE_LOOP_CATCHERS		0
 
 
 /***************************************************************************
@@ -138,6 +139,8 @@ static struct dac_state dac;
 static int dac_stream;
 static int cvsd_stream;
 
+static unsigned disable_firq_speedup;
+static unsigned disable_loop_catchers;
 
 /***************************************************************************
 	PROTOTYPES
@@ -710,6 +713,16 @@ void williams_narc_init(int cpunum)
 
 static void init_audio_state(int first_time)
 {
+        /* enable speedhacks */
+        disable_firq_speedup = 1;
+        disable_loop_catchers = 1;
+        
+        if(activate_williams_speedhack)
+        {
+            disable_firq_speedup = 0;
+            disable_loop_catchers = 0;
+        }
+    
 	/* reset the YM2151 state */
 	ym2151.timer_base = 1.0 / (3579580.0 / 64.0);
 	ym2151.timer_period[0] = ym2151.timer_period[1] = ym2151.timer_period[2] = 1.0;
@@ -1082,11 +1095,11 @@ static WRITE_HANDLER( williams_ym2151_w )
 	}
 	else
 	{
-		if (!DISABLE_FIRQ_SPEEDUP)
+		if (!disable_firq_speedup)
 			ym2151.current_register = data;
 
 		/* only pass through register writes for non-timer registers */
-		if (DISABLE_FIRQ_SPEEDUP || ym2151.current_register < 0x10 || ym2151.current_register > 0x14)
+		if (disable_firq_speedup || ym2151.current_register < 0x10 || ym2151.current_register > 0x14)
 			YM2151_register_port_0_w(offset, data);
 	}
 }
@@ -1141,7 +1154,7 @@ static void update_counter(void)
 	double time_since_update, timer_period = ym2151.timer_period[ym2151.active_timer];
 	int firqs_since_update, complete_ticks, downcounter;
 
-	if (DISABLE_FIRQ_SPEEDUP || ym2151.active_timer == 2 || counter.invalid)
+	if (disable_firq_speedup || ym2151.active_timer == 2 || counter.invalid)
 		return;
 
 	/* compute the time since we last updated; if it's less than one period, do nothing */
@@ -1208,7 +1221,7 @@ static READ_HANDLER( counter_value_r )
 	counter.last_read_pc = pc;
 
 	/* on the second LSB read in the hotspot, check to see if we will be looping */
-	if (offset == 1 && pc == counter.hotspot_start + 6 && !DISABLE_LOOP_CATCHERS)
+	if (offset == 1 && pc == counter.hotspot_start + 6 && !disable_loop_catchers)
 	{
 		UINT16 new_counter = counter.value[0] * 256 + counter.value[1];
 


### PR DESCRIPTION
…ames where it breaks the sound (MK T-Unit version).

Followed the same general structure as the DCS speedhack core option. Tested and confirmed it fixes audio for MK1 when the speedhack option is disabled. Requires a restart to apply the change.

Also tested several other Williams games (Judge Dredd, T2, Total Carnage, NBA Jam, NARC) and all seemed OK. 

Any comments or improvements feel free to suggest.