### PR TITLE
Leds

### DIFF
--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -32,6 +32,9 @@ static retro_input_state_t input_cb = NULL;
 static retro_audio_sample_batch_t audio_batch_cb = NULL;
 retro_environment_t environ_cb = NULL;
 
+unsigned long lastled = 0;
+retro_set_led_state_t led_state_cb = NULL;
+
 void retro_set_video_refresh(retro_video_refresh_t cb) { video_cb = cb; }
 void retro_set_audio_sample(retro_audio_sample_t cb) { }
 void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { audio_batch_cb = cb; }
@@ -320,6 +323,15 @@ static void update_variables(void)
    }
    else
       tate_mode = 0;
+
+
+   {
+       struct retro_led_interface ledintf;
+       ledintf.set_led_state = NULL;
+       
+       environ_cb(RETRO_ENVIRONMENT_GET_LED_INTERFACE, &ledintf);
+       led_state_cb = ledintf.set_led_state;
+   }
 }
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
@@ -488,6 +500,7 @@ void retro_run (void)
    mame_frame();
 
    audio_batch_cb(XsoundBuffer, Machine->sample_rate / Machine->drv->frames_per_second);
+
 }
 
 

--- a/src/libretro/libretro.h
+++ b/src/libretro/libretro.h
@@ -978,7 +978,7 @@ struct retro_hw_render_context_negotiation_interface
                                             * so it will be used after SET_HW_RENDER, but before the context_reset callback.
                                             */
 
-#define RETRO_ENVIRONMENT_GET_LED_INTERFACE (45 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+#define RETRO_ENVIRONMENT_GET_LED_INTERFACE (46 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                            /* struct retro_led_interface * --
                                             * Gets an interface which is used by a libretro core to set 
                                             * state of LEDs.

--- a/src/libretro/libretro.h
+++ b/src/libretro/libretro.h
@@ -978,6 +978,19 @@ struct retro_hw_render_context_negotiation_interface
                                             * so it will be used after SET_HW_RENDER, but before the context_reset callback.
                                             */
 
+#define RETRO_ENVIRONMENT_GET_LED_INTERFACE (45 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_led_interface * --
+                                            * Gets an interface which is used by a libretro core to set 
+                                            * state of LEDs.
+                                            */
+
+typedef void (RETRO_CALLCONV *retro_set_led_state_t)(int led, int state);
+struct retro_led_interface
+{
+    retro_set_led_state_t set_led_state;
+};
+
+
 /* Serialized state is incomplete in some way. Set if serialization is
  * usable in typical end-user cases but should not be relied upon to
  * implement frame-sensitive frontend features such as netplay or


### PR DESCRIPTION
Added support for outputing LED state from the mame2003 core to RetroArch.  It relies on this pull request to RetroArch which adds LED support:  https://github.com/libretro/RetroArch/pull/5968
