### PR TITLE
default BUILD_BIN2C to disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DEBUGGER=0
 SPLIT_UP_LINK=0
 CORE_DIR := src
 TARGET_NAME := mame2003
-BUILD_BIN2C ?= 1
+BUILD_BIN2C ?= 0
 
 GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")


### PR DESCRIPTION
per suggestion by @retro-wertz to only execute bin2c manually when needed, at least until there is a more sophisticated approach in the makefile