### PR TITLE
dont optimize code that breaks on most builds

### DIFF
--- a/src/vidhrdw/namcos1_vidhrdw.c
+++ b/src/vidhrdw/namcos1_vidhrdw.c
@@ -492,6 +492,10 @@ static void draw_sprites(struct mame_bitmap *bitmap,const struct rectangle *clip
 }
 #endif
 
+
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
+
 static void namcos1_draw_screen(struct mame_bitmap *bitmap, const struct rectangle *cliprect)
 {
 	int i, j, scrollx, scrolly, priority;
@@ -565,6 +569,7 @@ static void namcos1_draw_screen(struct mame_bitmap *bitmap, const struct rectang
 		draw_sprites(bitmap, cliprect, sp_updatebuffer);
 #endif
 }
+#pragma GCC pop_options
 
 
 VIDEO_START( namcos1 )


### PR DESCRIPTION
this will not optimize the bad code that breaks namcos1 on a few builds not sure how many no need to unoptimize the whole driver