### PR TITLE
fix es5506 (SSV games sound driftout95 twin eagel ect)

### DIFF
--- a/src/sound/es5506.c
+++ b/src/sound/es5506.c
@@ -1055,8 +1055,9 @@ static INLINE void es5506_reg_write_low(struct ES5506Chip *chip, struct ES5506Vo
 #ifdef LOG_COMMANDS
 			if (LOG_COMMANDS && eslog)
 				fprintf(eslog, "voice %d, left vol=%04x\n", chip->current_page & 0x1f, voice->lvol);
-			break;
 #endif
+			break;
+
 
 		case 0x18/8:	/* LVRAMP */
 			voice->lvramp = (data & 0xff00) >> 8;


### PR DESCRIPTION
Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
