### PR TITLE
change core name as reported to the libretro API to match the RA .info file

### DIFF
--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -263,7 +263,9 @@ unsigned retro_api_version(void)
 
 void retro_get_system_info(struct retro_system_info *info)
 {
-   info->library_name = APPNAME;
+   /* this must match the 'corename' field in mame2003_libretro.info
+    * in order for netplay to work. */
+   info->library_name = "MAME 2003 (0.78)";
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif


### PR DESCRIPTION
== DETAILS
When the APPNAME macro was added, the libretro code was included
in the change and doing so broke netplay in RetroArch.

RetroArch stores core information in *.info files, and the `corename`
field of the info file is expected to match what the core self-reports.
The result of the APPNAME macro work is that it changed the self-reporting
core name as "mame2003".

This commit changes the core self-reported name (and JUST that name) back
to the expected value.

== TESTING
Tested locally and confirmed that the content matching in netplay is now
successful.

@twinaphex 

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
