### PR TITLE
Fix vector graphics rendering settings

### DIFF
--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -180,13 +180,13 @@ void retro_set_environment(retro_environment_t cb)
       { APPNAME"-crosshair_enabled", "Show Lightgun crosshair; enabled|disabled" },
       { APPNAME"-rstick_to_btns", "Right Stick to Buttons; enabled|disabled" },
       { APPNAME"-tate_mode", "TATE Mode; disabled|enabled" },
-      { APPNAME"-skip-rom-verify", "EXPERIMENTAL: Skip ROM verification; disabled|enabled" }, 
-      { APPNAME"-vector-resolution-multiplier", "EXPERIMENTAL: Vector resolution multiplier; 1|2|3|4|5|6" },      
-      { APPNAME"-vector-antialias", "EXPERIMENTAL: Vector antialias; disabled" },
+      { APPNAME"-skip-rom-verify", "EXPERIMENTAL: Skip ROM verification; disabled|enabled" },
+      { APPNAME"-vector-resolution-multiplier", "Vector resolution multiplier; 1|2|3|4|5|6|7|8|9|10" },
+      { APPNAME"-vector-antialias", "Vector antialiasing; enabled|disabled" },
       { APPNAME"-vector-translucency", "Vector translucency; enabled|disabled" },
-      { APPNAME"-vector-beam-width", "Vector beam width; 1|2|3|4|5" },
+      { APPNAME"-vector-beam-width", "Vector beam width (AA only); 1|1.5|2|2.5|3|4|5|6|7|8|9|10" },
       { APPNAME"-vector-flicker", "Vector flicker; 20|0|10|20|30|40|50|60|70|80|90|100" },
-      { APPNAME"-vector-intensity", "Vector intensity; 1.5|0.5|1|2|2.5|3" },
+      { APPNAME"-vector-intensity", "Vector intensity; 1.5|0.5|1|1.5|2|2.5|3" },
       { NULL, NULL },
    };
    environ_cb = cb;
@@ -458,7 +458,7 @@ static void update_variables(void)
    var.key = APPNAME"-vector-beam-width";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      options.beam = atoi(var.value); /* integer: vector beam width */
+      options.beam = atof(var.value); /* float: vector beam width */
    }
  
    var.value = NULL;

--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -181,7 +181,7 @@ void retro_set_environment(retro_environment_t cb)
       { APPNAME"-rstick_to_btns", "Right Stick to Buttons; enabled|disabled" },
       { APPNAME"-tate_mode", "TATE Mode; disabled|enabled" },
       { APPNAME"-skip-rom-verify", "EXPERIMENTAL: Skip ROM verification; disabled|enabled" },
-      { APPNAME"-vector-resolution-multiplier (requires restart)", "Vector resolution multiplier; 1|2|3|4|5|6|7|8|9|10" },
+      { APPNAME"-vector-resolution-multiplier", "Vector resolution multiplier (requires restart); 1|2|3|4|5|6|7|8|9|10" },
       { APPNAME"-vector-antialias", "Vector antialiasing; enabled|disabled" },
       { APPNAME"-vector-translucency", "Vector translucency; enabled|disabled" },
       { APPNAME"-vector-beam-width", "Vector beam width (AA only); 1|1.5|2|2.5|3|4|5|6|7|8|9|10" },

--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -181,7 +181,7 @@ void retro_set_environment(retro_environment_t cb)
       { APPNAME"-rstick_to_btns", "Right Stick to Buttons; enabled|disabled" },
       { APPNAME"-tate_mode", "TATE Mode; disabled|enabled" },
       { APPNAME"-skip-rom-verify", "EXPERIMENTAL: Skip ROM verification; disabled|enabled" },
-      { APPNAME"-vector-resolution-multiplier", "Vector resolution multiplier; 1|2|3|4|5|6|7|8|9|10" },
+      { APPNAME"-vector-resolution-multiplier (requires restart)", "Vector resolution multiplier; 1|2|3|4|5|6|7|8|9|10" },
       { APPNAME"-vector-antialias", "Vector antialiasing; enabled|disabled" },
       { APPNAME"-vector-translucency", "Vector translucency; enabled|disabled" },
       { APPNAME"-vector-beam-width", "Vector beam width (AA only); 1|1.5|2|2.5|3|4|5|6|7|8|9|10" },

--- a/src/libretro/video.c
+++ b/src/libretro/video.c
@@ -16,7 +16,7 @@ static unsigned long prev_led_state = 0;
 
 #define MAX_LED 16
 
-uint16_t videoBuffer[1024*1024];
+uint16_t *videoBuffer;
 struct osd_create_params videoConfig;
 int gotFrame;
 
@@ -66,11 +66,21 @@ int osd_create_display(const struct osd_create_params *params, UINT32 *rgb_compo
       rgb_components[2] = 0x0000FF;
    }
 
+   /* allocate a buffer for color conversion from non-32bpp modes */
+   if (Machine->color_depth != 32) {
+       videoBuffer = malloc(params->width * params->height * 4);
+   }
+
    return 0;
 }
 
 void osd_close_display(void)
 {
+   if (videoBuffer != 0)
+   {
+      free(videoBuffer);
+      videoBuffer = 0;
+   }
 }
 
 static const int frameskip_table[12][12] = { { 0,0,0,0,0,0,0,0,0,0,0,0 },

--- a/src/mame.c
+++ b/src/mame.c
@@ -646,8 +646,7 @@ static int vh_open(void)
 	/* if we're a vector game, override the screen width and height */
 	if (Machine->drv->video_attributes & VIDEO_TYPE_VECTOR)
     {
-       /*scale_vectorgames(options.vector_width, options.vector_height, &bmwidth, &bmheight);*/      
-       /*Hack to avoid segfault: leave vector resolution to its default the first time scale_vectorgames is caused*/
+       scale_vectorgames(options.vector_width, options.vector_height, &bmwidth, &bmheight);
     }
 	/* compute the visible area for raster games */
 	if (!(Machine->drv->video_attributes & VIDEO_TYPE_VECTOR))
@@ -677,9 +676,7 @@ static int vh_open(void)
 	/* the create display process may update the vector width/height, so recompute */
 	if (Machine->drv->video_attributes & VIDEO_TYPE_VECTOR)
     {
-        //scale_vectorgames((options.vector_resolution_multiplier * Machine->drv->screen_width), (options.vector_resolution_multiplier * Machine->drv->screen_height), &bmwidth, &bmheight);
-        bmwidth = Machine->drv->screen_width * options.vector_resolution_multiplier;
-        bmheight = Machine->drv->screen_height * options.vector_resolution_multiplier;
+        scale_vectorgames(options.vector_width, options.vector_height, &bmwidth, &bmheight);
     }
     
     
@@ -834,11 +831,14 @@ static int init_game_options(void)
 	alpha_active = 0;
 	if (Machine->drv->video_attributes & VIDEO_RGB_DIRECT)
 	{
-		/* first pick a default */
+		/* first pick a default
 		if (Machine->drv->video_attributes & VIDEO_NEEDS_6BITS_PER_GUN)
 			Machine->color_depth = 32;
 		else
-			Machine->color_depth = 15;
+			Machine->color_depth = 15;*/
+
+		/* use 32-bit color output as default to skip color conversions */
+		Machine->color_depth = 32;
 
 		/* now allow overrides */
 		if (options.color_depth == 15 || options.color_depth == 32)
@@ -850,8 +850,12 @@ static int init_game_options(void)
 	}
 
 	/* update the vector width/height with defaults */
-	if (options.vector_width == 0) options.vector_width = 640;
-	if (options.vector_height == 0) options.vector_height = 480;
+	if (options.vector_width == 0) options.vector_width = Machine->drv->screen_width;
+	if (options.vector_height == 0) options.vector_height = Machine->drv->screen_height;
+
+	/* apply the vector resolution multiplier */
+	options.vector_width *= options.vector_resolution_multiplier;
+	options.vector_height *= options.vector_resolution_multiplier;
 
 	/* initialize the samplerate */
         if ( (  Machine->drv->frames_per_second < 47 ) && (options.samplerate >= 30000) )	

--- a/src/mame.h
+++ b/src/mame.h
@@ -199,7 +199,7 @@ struct GameOptions
         
 	int		 vector_width;	        /* requested width for vector games; 0 means default (640) */
 	int		 vector_height;	        /* requested height for vector games; 0 means default (480) */
-	int		 beam;			        /* vector beam width */
+	float	 beam;			        /* vector beam width */
 	float	 vector_flicker;	    /* vector beam flicker effect control */
 	float	 vector_intensity;      /* vector beam intensity */
 	int		 translucency;	        /* 1 to enable translucency on vectors */

--- a/src/vidhrdw/vector.c
+++ b/src/vidhrdw/vector.c
@@ -179,6 +179,20 @@ float vector_get_intensity(void)
 	return intensity_correction;
 }
 
+static void update_options(void)
+{
+	antialias = options.antialias;
+	translucency = options.translucency;
+	vector_set_flicker(options.vector_flicker);
+	vector_set_intensity(options.vector_intensity);
+	
+	/* Beam width is encoded as fixed point */
+	beam = (int)(options.beam * 0x00010000);
+	beam = beam > 0x00100000 ? 0x00100000 : beam;
+	beam = beam < 0x00010000 ? 0x00010000 : beam;
+	beam_diameter_is_one = beam == 0x00010000;
+}
+
 /*
  * Initializes vector game video emulation
  */
@@ -187,18 +201,8 @@ VIDEO_START( vector )
 {
 	int i;
 
-	/* Grab the settings for this session */
-	antialias = options.antialias;
-	translucency = options.translucency;
-	vector_set_flicker(options.vector_flicker);
-	vector_set_intensity(options.vector_intensity);
-	beam = options.beam;
-
-
-	if (beam == 0x00010000)
-		beam_diameter_is_one = 1;
-	else
-		beam_diameter_is_one = 0;
+	/* Set initial rendering options */
+	update_options();
 
 	p_index = 0;
 
@@ -759,6 +763,9 @@ VIDEO_UPDATE( vector )
 
 	/* clear ALL pixels in the hidden map */
 	vector_clear_pixels();
+
+	/* Update rendering options once the screen is clear */
+	update_options();
 
 	/* Draw ALL lines into the hidden map. Mark only those lines with */
 	/* new->dirty = 1 as dirty. Remember the pixel start/end indices  */


### PR DESCRIPTION
Finally sat down and made a clean fix for #332.

The problems were: incorrect beam width setting parsing leading to an infinite loop on antialias enabled; plain wrong resolution multiplier setting handling leading to a clipped screen; incorrect memory buffer handling leading to crashes. All fixed.

As an extra, I've set the default color depth for non-palette modes to 32bpp as used by video.c internally. A no-brainer, really - the core otherwise wastes an exorbitant amount of time doing the conversion every frame. This yields noticeable FPS increase on higher output resolutions.

Will post more details on the issue page.