### PR TITLE
Native video rotation fixes, cleanups, refactoring

### DIFF
--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -178,7 +178,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       { APPNAME"-crosshair_enabled", "Show Lightgun crosshair; enabled|disabled" },
       { APPNAME"-rstick_to_btns", "Right Stick to Buttons; enabled|disabled" },
-      { APPNAME"-tate_mode", "TATE Mode (vertical games 90° CCW screen rotation); disabled|enabled" },
+      { APPNAME"-tate_mode", "TATE Mode (rotate vertical games by 90 degree CCW); disabled|enabled" },
       { APPNAME"-skip-rom-verify", "EXPERIMENTAL: Skip ROM verification; disabled|enabled" },
       { APPNAME"-vector-resolution-multiplier", "Vector resolution multiplier (Restart core); 1|2|3|4|5|6|7|8|9|10" },
       { APPNAME"-vector-antialias", "Vector antialiasing; enabled|disabled" },

--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -49,7 +49,7 @@ retro_set_led_state_t led_state_cb = NULL;
 
 int16_t XsoundBuffer[2048];
 
-void mame2003_video_get_geometry(unsigned *width, unsigned *height);
+extern void mame2003_video_get_geometry(struct retro_game_geometry *geom);
 
 #ifdef _3DS /* TODO: convert this strcasecmp wrapper to libretro-common/compat functions */
 int stricmp(const char *string1, const char *string2)
@@ -488,13 +488,8 @@ static void update_variables(void)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-   unsigned width, height;
-   mame2003_video_get_geometry(&width, &height);
-
-   info->geometry.base_width = width;
-   info->geometry.base_height = height;
-   info->geometry.max_width = width;
-   info->geometry.max_height = height;
+   mame2003_video_get_geometry(&info->geometry);
+   
    info->timing.fps = Machine->drv->frames_per_second; /* sets the core timing does any game go above 60fps? */
    info->timing.sample_rate = options.samplerate;  /* please note if you want bally games to work properly set the sample rate to 22050 you cant go below 48 frames with the default that is set you will need to restart the core */
 }

--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -178,7 +178,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       { APPNAME"-crosshair_enabled", "Show Lightgun crosshair; enabled|disabled" },
       { APPNAME"-rstick_to_btns", "Right Stick to Buttons; enabled|disabled" },
-      { APPNAME"-tate_mode", "TATE Mode (rotate vertical games by 90 degree CCW); disabled|enabled" },
+      { APPNAME"-tate_mode", "TATE Mode (rotate vertical games by 90 degrees CCW); disabled|enabled" },
       { APPNAME"-skip-rom-verify", "EXPERIMENTAL: Skip ROM verification; disabled|enabled" },
       { APPNAME"-vector-resolution-multiplier", "Vector resolution multiplier (Restart core); 1|2|3|4|5|6|7|8|9|10" },
       { APPNAME"-vector-antialias", "Vector antialiasing; enabled|disabled" },

--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -178,7 +178,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       { APPNAME"-crosshair_enabled", "Show Lightgun crosshair; enabled|disabled" },
       { APPNAME"-rstick_to_btns", "Right Stick to Buttons; enabled|disabled" },
-      { APPNAME"-tate_mode", "TATE Mode (90° CCW screen rotate); disabled|enabled" },
+      { APPNAME"-tate_mode", "TATE Mode (vertical games 90° CCW screen rotation); disabled|enabled" },
       { APPNAME"-skip-rom-verify", "EXPERIMENTAL: Skip ROM verification; disabled|enabled" },
       { APPNAME"-vector-resolution-multiplier", "Vector resolution multiplier (Restart core); 1|2|3|4|5|6|7|8|9|10" },
       { APPNAME"-vector-antialias", "Vector antialiasing; enabled|disabled" },
@@ -489,7 +489,7 @@ static void update_variables(void)
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
    mame2003_video_get_geometry(&info->geometry);
-   
+
    info->timing.fps = Machine->drv->frames_per_second; /* sets the core timing does any game go above 60fps? */
    info->timing.sample_rate = options.samplerate;  /* please note if you want bally games to work properly set the sample rate to 22050 you cant go below 48 frames with the default that is set you will need to restart the core */
 }

--- a/src/libretro/video.c
+++ b/src/libretro/video.c
@@ -362,25 +362,27 @@ void osd_update_video_and_audio(struct mame_display *display)
          video_palette = display->game_palette;
 
       /* Update the game bitmap */
-      if (video_cb && !osd_skip_this_frame())
+      if (video_cb)
       {
-         if (video_do_bypass)
+         if (!osd_skip_this_frame())
          {
-            unsigned min_y = display->game_visible_area.min_y;
-            unsigned min_x = display->game_visible_area.min_x;
-            unsigned pitch = display->game_bitmap->rowbytes;
-            char *base = &((char **)display->game_bitmap->line)[min_y][min_x];
-            video_cb(base, vis_width, vis_height, pitch);
+            if (video_do_bypass)
+            {
+               unsigned min_y = display->game_visible_area.min_y;
+               unsigned min_x = display->game_visible_area.min_x;
+               unsigned pitch = display->game_bitmap->rowpixels * video_stride_out;
+               char *base = &((char*)display->game_bitmap->base)[min_y*pitch + min_x*video_stride_out];
+               video_cb(base, vis_width, vis_height, pitch);
+            }
+            else
+            {
+               frame_convert(display);
+               video_cb(video_buffer, vis_width, vis_height, vis_width * video_stride_out);
+            }
          }
          else
-         {
-            frame_convert(display);
-            video_cb(video_buffer, vis_width, vis_height, vis_width * video_stride_out);
-         }
-
+            video_cb(NULL, vis_width, vis_height, vis_width * video_stride_out);
       }
-      else
-         video_cb(NULL, vis_width, vis_height, vis_width * video_stride_out);
    }
 
    /* Update LED indicators state */

--- a/src/libretro/video.c
+++ b/src/libretro/video.c
@@ -8,27 +8,27 @@
 #include "usrintrf.h"
 #include "driver.h"
 
+#define MAX_LED 16
+
 extern retro_log_printf_t log_cb;
 extern retro_environment_t environ_cb;
 extern retro_video_refresh_t video_cb;
 extern retro_set_led_state_t led_state_cb;
-static unsigned long prev_led_state = 0;
 
-#define MAX_LED 16
+extern struct RunningMachine *Machine;
 
-uint16_t *videoBuffer;
-struct osd_create_params videoConfig;
-extern unsigned retroOrientation;
-extern unsigned retroColorMode;
-int gotFrame;
+struct osd_create_params video_config;
 
-/* Various conversion/transformation settings */
-struct {
-   const rgb_t *palette;
-   bool flip_x, flip_y, swap_xy;
-   ptrdiff_t stride_in, stride_out;
-   void (*pix_convert)(void *from, void *to);
-} videoConversion;
+/* Part of libretro's API */
+extern int gotFrame;
+
+/* Native frame conversion/transformation related vars */
+const rgb_t *video_palette;
+void (*video_pix_convert)(void *from, void *to);
+unsigned video_stride_in, video_stride_out;
+bool video_flip_x, video_flip_y, video_swap_xy;
+bool video_hw_rotate;
+uint16_t *video_buffer;
 
 /* Single pixel conversion functions */
 static void pix_convert_pass8888(void *from, void *to);
@@ -36,90 +36,155 @@ static void pix_convert_1555to565(void *from, void *to);
 static void pix_convert_passpal(void *from, void *to);
 static void pix_convert_palto565(void *from, void *to);
 
-
-int osd_create_display(
-   const struct osd_create_params *params, UINT32 *rgb_components)
+/* Compute a reverse of a given orientation, accounting for XY swaps */
+static unsigned reverse_orientation(unsigned orientation)
 {
-   memcpy(&videoConfig, params, sizeof(videoConfig));    
+   int result = orientation;
+   if (orientation & ORIENTATION_SWAP_XY)
+   {
+      result = ORIENTATION_SWAP_XY;
+      if (orientation & ORIENTATION_FLIP_X)
+         result ^= ORIENTATION_FLIP_Y;
+      if (orientation & ORIENTATION_FLIP_Y)
+         result ^= ORIENTATION_FLIP_X;
+   }
+   return result;
+}
+
+/* Retrieve output geometry (i.e. window dimensions) */
+void mame2003_video_get_geometry(unsigned *width, unsigned *height)
+{
+   *width = video_hw_rotate ? video_config.height : video_config.width;
+   *height = video_hw_rotate ? video_config.width : video_config.height;
+}
+
+/* Init orientation and geometry */
+void mame2003_video_init_orientation(void)
+{
+   unsigned orientation = Machine->gamedrv->flags & ORIENTATION_MASK;
+   unsigned rotate_mode = 0;
+
+   /*
+      The UI is always oriented properly at start, but the externally applied
+      orientation needs to be countered.
+   */
+   options.ui_orientation = reverse_orientation(orientation);
+
+   /* TATE mode (90 degree CCW rotation), however, isn't countered */
+   if (options.tate_mode)
+   {
+      if ((orientation & ROT180) == ORIENTATION_FLIP_X ||
+	    (orientation & ROT180) == ORIENTATION_FLIP_Y)
+         orientation ^= ROT180;
+      orientation ^= ROT270;
+   }
+
+   /* Try to match orientation to a supported libretro rotation */
+   rotate_mode = (orientation == ROT270) ? 1 : rotate_mode;
+   rotate_mode = (orientation == ROT180) ? 2 : rotate_mode;
+   rotate_mode = (orientation == ROT90) ? 3 : rotate_mode;
+
+   video_hw_rotate = false;
+
+   /* Try to use libretro to do a rotation */
+   if (rotate_mode != 0
+         && environ_cb(RETRO_ENVIRONMENT_SET_ROTATION, &rotate_mode))
+   {
+      video_hw_rotate = orientation & ORIENTATION_SWAP_XY;
+      orientation = 0;
+   }
+
+   /* Set up native orientation flags that aren't handled by libretro */
+   video_flip_x = orientation & ORIENTATION_FLIP_X;
+   video_flip_y = orientation & ORIENTATION_FLIP_Y;
+   video_swap_xy = orientation & ORIENTATION_SWAP_XY;
+
+   Machine->ui_orientation = options.ui_orientation;
+
+   /* Adjust for libretro's rotation not resizing output geometry */
+   if (orientation & ORIENTATION_SWAP_XY)
+   {
+      int width = video_config.width;
+      int height = video_config.height;
+      
+      video_config.width = height;
+      video_config.height = width;
+   }
+}
+
+void mame2003_video_init_conversion(UINT32 *rgb_components)
+{
+   unsigned color_mode;
 
    /* Case I: 16-bit indexed palette */
-   if (videoConfig.depth == 16)
+   if (video_config.depth == 16)
    {
       /* If a 6+ bits per color channel palette is used, do 32-bit XRGB8888 */
-      if (videoConfig.video_attributes & VIDEO_NEEDS_6BITS_PER_GUN)
+      if (video_config.video_attributes & VIDEO_NEEDS_6BITS_PER_GUN)
       {
-         retroColorMode = RETRO_PIXEL_FORMAT_XRGB8888;
-
-         videoConversion.stride_in = 2;
-         videoConversion.stride_out = 4;
-         videoConversion.pix_convert = &pix_convert_passpal;
+         video_stride_in = 2; video_stride_out = 4;
+         video_pix_convert = &pix_convert_passpal;
+         color_mode = RETRO_PIXEL_FORMAT_XRGB8888;
       }
-      /* Otherwise 16-bit 0RGB1555 will suffice */
+      /* Otherwise 16-bit RGB565 will suffice */
       else
       {
-         retroColorMode = RETRO_PIXEL_FORMAT_RGB565;
-
-         videoConversion.stride_in = 2;
-         videoConversion.stride_out = 2;
-         videoConversion.pix_convert = &pix_convert_palto565;
+         video_stride_in = 2; video_stride_out = 2;
+         video_pix_convert = &pix_convert_palto565;
+         color_mode = RETRO_PIXEL_FORMAT_RGB565;
       }
    }
 
    /* Case II: 32-bit XRGB8888, pass it through */
-   else if (videoConfig.depth == 32)
+   else if (video_config.depth == 32)
    {
-      retroColorMode = RETRO_PIXEL_FORMAT_XRGB8888;
+      video_stride_in = 4; video_stride_out = 4;
+      video_pix_convert = &pix_convert_pass8888;
+      color_mode = RETRO_PIXEL_FORMAT_XRGB8888;
 
+      /* TODO: figure those out */
       rgb_components[0] = 0x00FF0000;
       rgb_components[1] = 0x0000FF00;
       rgb_components[2] = 0x000000FF;
-
-      videoConversion.stride_in = 4;
-      videoConversion.stride_out = 4;
-      videoConversion.pix_convert = &pix_convert_pass8888;
    }
 
    /* Case III: 16-bit 0RGB1555, convert it to RGB565 */
    else
    {
-      /* Complain if got here by default */
-      if (videoConfig.depth != 15) {
-         if (log_cb)
-            log_cb(RETRO_LOG_ERROR, "Invalid videoConfig.depth (%u)", videoConfig.depth);
-         else
-            fprintf(stderr, "Invalid videoConfig.depth (%u)\n", videoConfig.depth);
-      }
+      video_stride_in = 2; video_stride_out = 2;
+      video_pix_convert = &pix_convert_1555to565;
+      color_mode = RETRO_PIXEL_FORMAT_RGB565;
 
-      retroColorMode = RETRO_PIXEL_FORMAT_RGB565;
-
+      /* TODO: figure those out */
       rgb_components[0] = 0x00007C00;
       rgb_components[1] = 0x000003E0;
       rgb_components[2] = 0x0000001F;
-
-      videoConversion.stride_in = 2;
-      videoConversion.stride_out = 2;
-      videoConversion.pix_convert = &pix_convert_1555to565;
    }
 
-   /* Set up software rotation flags that aren't handled by libretro */
-   videoConversion.flip_x = (bool)(retroOrientation & ORIENTATION_FLIP_X);
-   videoConversion.flip_y = (bool)(retroOrientation & ORIENTATION_FLIP_Y);
-   videoConversion.swap_xy = (bool)(retroOrientation & ORIENTATION_SWAP_XY);
+   environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &color_mode);
+}
+
+int osd_create_display(
+   const struct osd_create_params *params, UINT32 *rgb_components)
+{
+   memcpy(&video_config, params, sizeof(video_config));    
+
+   /* Determine video orientation and pixel format conversion settings */
+   mame2003_video_init_orientation();
+   mame2003_video_init_conversion(rgb_components);
 
    /* Allocate an output video buffer */
-   videoBuffer = malloc(videoConfig.width * videoConfig.height * videoConversion.stride_out);
-   if (!videoBuffer)
+   video_buffer = malloc(video_config.width * video_config.height * video_stride_out);
+   if (!video_buffer)
       return 1;
-
-   environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &retroColorMode);
 
    return 0;
 }
 
 void osd_close_display(void)
 {
-   free(videoBuffer);
-   videoBuffer = NULL;
+   free(video_buffer);
+   video_buffer = NULL;
 }
 
 static void pix_convert_pass8888(void *from, void *to)
@@ -136,13 +201,13 @@ static void pix_convert_1555to565(void *from, void *to)
 
 static void pix_convert_passpal(void *from, void *to)
 {
-   const uint32_t color = videoConversion.palette[*((uint16_t*)from)];
+   const uint32_t color = video_palette[*((uint16_t*)from)];
    *((uint32_t*)to) = color;
 }
 
 static void pix_convert_palto565(void *from, void *to)
 {
-   const uint32_t color = videoConversion.palette[*((uint16_t*)from)];
+   const uint32_t color = video_palette[*((uint16_t*)from)];
    *((uint16_t*)to) = (color & 0x00F80000) >> 8 | /* red */
                       (color & 0x0000FC00) >> 5 | /* green */
                       (color & 0x000000F8) >> 3;  /* blue */
@@ -150,41 +215,41 @@ static void pix_convert_palto565(void *from, void *to)
 
 static void frame_convert(struct mame_display *display)
 {
-   size_t x, y, swap_temp;
+   int x, y;
 
-   char **lines = (char **) display->game_bitmap->line;
+   bool flip_x = video_flip_x;
+   bool flip_y = video_flip_y;
 
-   /* Initial (default) orientation */
-   const bool flip_x = videoConversion.flip_x;
-   const bool flip_y = videoConversion.flip_y;
-   size_t x0 = display->game_visible_area.min_x;
-   size_t y0 = display->game_visible_area.min_y;
-   size_t x1 = display->game_visible_area.max_x + 1;
-   size_t y1 = display->game_visible_area.max_y + 1;
+   struct rectangle visible_area = display->game_visible_area;
+   int x0 = visible_area.min_x;
+   int y0 = visible_area.min_y;
+   int x1 = visible_area.max_x;
+   int y1 = visible_area.max_y;
  
-   /* Now do the conversion, accounting for x/y swap */
-   if (!videoConversion.swap_xy)
+   char *output = (char*)video_buffer;
+   char **lines = (char**)display->game_bitmap->line;
+
+   /* Now do the conversion, accounting for x/y swaps */
+   if (!video_swap_xy)
    {
       /* Non-swapped */
-      char *output = (char*)videoBuffer;
-      for (y = flip_y ? y1 : y0; y != (flip_y ? y0 : y1); y += flip_y ? -1 : 1)
-         for (x = flip_x ? x1 : x0; x != (flip_x ? x0 : x1); x += flip_x ? -1 : 1)
+      for (y = flip_y ? y1 : y0; flip_y ? y >= y0 : y <= y1; y += flip_y ? -1 : 1)
+         for (x = flip_x ? x1 : x0; flip_x ? x >= x0 : x <= x1; x += flip_x ? -1 : 1)
          {
-            videoConversion.pix_convert(
-               &lines[y][x * videoConversion.stride_in], output);
-            output += videoConversion.stride_out;
+            video_pix_convert(
+               &lines[y][x * video_stride_in], output);
+            output += video_stride_out;
          }
    }
    else
    {
       /* Swapped */
-      char *output = (char *) videoBuffer;
-      for (x = flip_y ? x1 : x0; x != (flip_y ? x0 : x1); x += flip_y ? -1 : 1)
-         for (y = flip_x ? y1 : y0; y != (flip_x ? y0 : y1); y += flip_x ? -1 : 1)
+      for (x = flip_y ? x1 : x0; flip_y ? x >= x0 : x <= x1; x += flip_y ? -1 : 1)
+         for (y = flip_x ? y1 : y0; flip_x ? y >= y0 : y <= y1; y += flip_x ? -1 : 1)
          {
-            videoConversion.pix_convert(
-               &lines[y][x * videoConversion.stride_in], output);
-            output += videoConversion.stride_out;
+            video_pix_convert(
+               &lines[y][x * video_stride_in], output);
+            output += video_stride_out;
          }
    }
 }
@@ -220,8 +285,8 @@ void osd_update_video_and_audio(struct mame_display *display)
       | GAME_VISIBLE_AREA_CHANGED | VECTOR_PIXELS_CHANGED))
    {
       size_t width, height;
-      width = videoConfig.width;
-      height = videoConfig.height;
+      width = video_config.width;
+      height = video_config.height;
 
       /* Update the UI area */
       if (display->changed_flags & GAME_VISIBLE_AREA_CHANGED)
@@ -232,16 +297,16 @@ void osd_update_video_and_audio(struct mame_display *display)
       }
 
       /* Update the palette */
-      videoConversion.palette = display->game_palette;
+      video_palette = display->game_palette;
 
       /* Update the game bitmap */
       if (video_cb && display->changed_flags & GAME_BITMAP_CHANGED && (osd_skip_this_frame() == 0))
       {
          frame_convert(display);
-         video_cb(videoBuffer, width, height, width * videoConversion.stride_out);
+         video_cb(video_buffer, width, height, width * video_stride_out);
       }
       else
-         video_cb(NULL, width, height, width * videoConversion.stride_out);
+         video_cb(NULL, width, height, width * video_stride_out);
    }
 
    /* Update LED indicators state */
@@ -249,7 +314,8 @@ void osd_update_video_and_audio(struct mame_display *display)
    {
        if(led_state_cb != NULL)
        {
-           // Set each changed LED
+           /* Set each changed LED */
+           static unsigned long prev_led_state = 0;
            unsigned long o = prev_led_state;
            unsigned long n = display->led_state;
            int led;

--- a/src/libretro/video.c
+++ b/src/libretro/video.c
@@ -56,23 +56,20 @@ static unsigned reverse_orientation(unsigned orientation)
 /* Retrieve output geometry (i.e. window dimensions) */
 void mame2003_video_get_geometry(struct retro_game_geometry *geom)
 {
-   geom->base_width =
-      (vis_width && vis_height) ? vis_width : video_config.width;
-   geom->base_height =
-      (vis_width && vis_height) ? vis_height : video_config.height;
+   geom->max_width = video_config.width;
+   geom->max_height = video_config.height;
+   geom->base_width = (vis_width && vis_height) ? vis_width : geom->max_width;
+   geom->base_height = (vis_width && vis_height) ? vis_height : geom->max_height;
 
    /* Adjust for libretro's rotation not resizing output geometry */
    if (video_hw_rotate)
    {
       unsigned temp;
       temp = geom->base_width; geom->base_width = geom->base_height; geom->base_height = temp;
+      temp = geom->max_width; geom->max_width = geom->max_height; geom->max_height = temp;
    }
 
-   geom->max_width = geom->base_width;
-   geom->max_height = geom->base_height;
-
-   geom->aspect_ratio =
-      (float)geom->max_width / (float)geom->max_height;
+   geom->aspect_ratio = (float)geom->max_width / (float)geom->max_height;
 }
 
 void mame2003_video_update_visible_area(struct mame_display *display)
@@ -113,8 +110,8 @@ void mame2003_video_init_orientation(void)
    */
    options.ui_orientation = reverse_orientation(orientation);
 
-   /* TATE mode (90 degree CCW rotation), however, isn't countered */
-   if (options.tate_mode)
+   /* Do a 90 degree CCW rotation for vertical games in TATE mode */
+   if (options.tate_mode && orientation & ORIENTATION_SWAP_XY)
    {
       if ((orientation & ROT180) == ORIENTATION_FLIP_X ||
 	    (orientation & ROT180) == ORIENTATION_FLIP_Y)

--- a/src/libretro/video.c
+++ b/src/libretro/video.c
@@ -283,15 +283,22 @@ void osd_update_video_and_audio(struct mame_display *display)
       ( GAME_BITMAP_CHANGED | GAME_PALETTE_CHANGED
       | GAME_VISIBLE_AREA_CHANGED | VECTOR_PIXELS_CHANGED))
    {
-      size_t width, height;
-      width = video_config.width;
-      height = video_config.height;
+      struct rectangle visible_area = display->game_visible_area;
+      unsigned width = visible_area.max_x - visible_area.min_x + 1;
+      unsigned height = visible_area.max_y - visible_area.min_y + 1;
+
+      /* Account for native XY swap */
+      if (video_swap_xy)
+      {
+         unsigned temp;
+         temp = width; width = height; height = temp;
+      }
 
       /* Update the UI area */
       if (display->changed_flags & GAME_VISIBLE_AREA_CHANGED)
          set_ui_visarea(
-            display->game_visible_area.min_x, display->game_visible_area.min_y,
-            display->game_visible_area.max_x, display->game_visible_area.max_y);
+            visible_area.min_x, visible_area.min_y,
+            visible_area.max_x, visible_area.max_y);
 
       /* Update the palette */
       if (display->changed_flags & GAME_PALETTE_CHANGED)

--- a/src/mame.c
+++ b/src/mame.c
@@ -832,14 +832,11 @@ static int init_game_options(void)
 	alpha_active = 0;
 	if (Machine->drv->video_attributes & VIDEO_RGB_DIRECT)
 	{
-		/* first pick a default
+		/* first pick a default */
 		if (Machine->drv->video_attributes & VIDEO_NEEDS_6BITS_PER_GUN)
 			Machine->color_depth = 32;
 		else
-			Machine->color_depth = 15;*/
-
-		/* use 32-bit color output as default to skip color conversions */
-		Machine->color_depth = 32;
+			Machine->color_depth = 15;
 
 		/* now allow overrides */
 		if (options.color_depth == 15 || options.color_depth == 32)
@@ -851,21 +848,23 @@ static int init_game_options(void)
 	}
 
 	/* update the vector width/height with defaults */
-	if (options.vector_width == 0) options.vector_width = Machine->drv->screen_width;
-	if (options.vector_height == 0) options.vector_height = Machine->drv->screen_height;
+	if (options.vector_width == 0)
+		options.vector_width = Machine->drv->screen_width;
+	if (options.vector_height == 0)
+		options.vector_height = Machine->drv->screen_height;
 
 	/* apply the vector resolution multiplier */
 	options.vector_width *= options.vector_resolution_multiplier;
 	options.vector_height *= options.vector_resolution_multiplier;
 
 	/* initialize the samplerate */
-        if ( (  Machine->drv->frames_per_second < 47 ) && (options.samplerate >= 30000) )	
-        {	
-                printf("sample rate too high\n");	
-                framerate_test =1;	
-                options.samplerate=22050;	
-                framerate_test =1;	
-        }        
+	if ( (  Machine->drv->frames_per_second < 47 ) && (options.samplerate >= 30000) )	
+	{	
+		printf("sample rate too high\n");	
+		framerate_test =1;	
+		options.samplerate=22050;	
+		framerate_test =1;	
+	}        
 	Machine->sample_rate = options.samplerate;
 
 	/* get orientation right */


### PR DESCRIPTION
Finally made a proper fix for #386 & #341, after the botched one at #389. While suboptimal (see below), it should actually handle all rotations correctly, both with or without libretro rotate support. TATE mode now works, too. I've also done some refactoring, moving all orientation-related parts to video.c. All in all, the code should now be more readable and maintainable. Sorry for the long wait, and thanks @grant2258 for testing the previous fix and pointing me in the right direction!

Oh, and please do contact me if you want to merge this in mame2003-plus, I prefer to make the necessary changes myself.

What else can be done:
- Using libretro's rotations for image transpose, when an exact rotation is unavailable. I'm just not smart enough to do all this bit fiddling, so I got fed up and scrapped it.
- Using cache-oblivious algo for image transpose. The present naive way of transposing images is a murder on the data cache, costing some 10-15% of average FPS.
- Bypassing frame copying when the output is in a supported format already. For now this is only useful for vector games, as most other games actually allocate larger frames and clip outputs, precluding this optimization.
- Supporting display size change on the fly, both for TATE mode and vector multiplier changes. Can be done easily, I'm just too tired of this code to do this right now.
- Using libretro-provided framebuffer. Actually, it turned out to be error-prone and useless: it's only implemented for Vulkan, and if a device supports Vulkan it's highly unlikely to be bandwidth-starved.