### PR TITLE
always use external hiscore.dat if present

### DIFF
--- a/src/hiscore.c
+++ b/src/hiscore.c
@@ -6,7 +6,7 @@
 
 #include "driver.h"
 #include "hiscore.h"
-/*#include "log.h"*/
+#include "log.h"
 #include "../precompile/hiscore_dat.h"
 
 #define MAX_CONFIG_LINE_SIZE 48
@@ -166,7 +166,7 @@ static void hs_load (void)
 	if (f)
 	{
 		struct mem_range *mem_range = state.mem_range;
-		log_cb(RETRO_LOG_INFO, "[MAME 2003] loading %s.hi hiscore memory file...\n", Machine->gamedrv->name);
+		log_cb(RETRO_LOG_INFO, LOGPRE "loading %s.hi hiscore memory file...\n", Machine->gamedrv->name);
         
 		while (mem_range)
 		{
@@ -193,7 +193,7 @@ static void hs_save (void)
 	if (f)
 	{
 		struct mem_range *mem_range = state.mem_range;
-		log_cb(RETRO_LOG_INFO, "[MAME 2003] saving %s.hi hiscore memory file...\n", Machine->gamedrv->name);
+		log_cb(RETRO_LOG_INFO, LOGPRE "saving %s.hi hiscore memory file...\n", Machine->gamedrv->name);
 		while (mem_range)
 		{
 			UINT8 *data = malloc (mem_range->num_bytes);
@@ -229,7 +229,7 @@ void hs_open (const char *name)
   
   if(!db_file)
   {
-      printf("hiscore.dat not found: generating new hiscore.dat\n");
+      log_cb(RETRO_LOG_INFO, LOGPRE "hiscore.dat not found: generating new hiscore.dat\n");
     	db_file = mame_fopen(NULL, db_filename, FILETYPE_HIGHSCORE_DB, 1);
 			mame_fwrite(db_file, hiscoredat_bytes, hiscoredat_length); 
 			mame_fclose(db_file);
@@ -238,7 +238,7 @@ void hs_open (const char *name)
   db_file = mame_fopen(NULL, db_filename, FILETYPE_HIGHSCORE_DB, 0);
   if(!db_file)
   {
-    printf("Failure generating hiscore.dat!\n");
+    log_cb(RETRO_LOG_ERROR, LOGPRE "Failure generating hiscore.dat!\n");
     return;
   }
 
@@ -249,7 +249,7 @@ void hs_open (const char *name)
       if (matching_game_name (buffer, name))
       {
         mode = FIND_DATA;
-        printf("%s hiscore memory map found in hiscore.dat!\n", name);
+        log_cb(RETRO_LOG_INFO, LOGPRE "%s hiscore memory map found in hiscore.dat!\n", name);
       }
     }
     else if (is_mem_range (buffer))

--- a/src/hiscore.h
+++ b/src/hiscore.h
@@ -2,17 +2,11 @@
 #define HISCORE_H
 
 void hs_open( const char *name );
-char *parse_hiscoredat(char *s, int n, int *const index);
 void hs_init( void );
 void hs_update( void );
 void hs_close( void );
 
 void computer_writemem_byte(int cpu, int addr, int value);
 int computer_readmem_byte(int cpu, int addr);
-
-extern const unsigned char hiscoredat_bytes[];
-extern const unsigned int hiscoredat_length;
-extern unsigned use_external_hiscore; 
-extern retro_log_printf_t log_cb;
 
 #endif /* HISCORE_H */

--- a/src/libretro/mame2003.c
+++ b/src/libretro/mame2003.c
@@ -164,7 +164,6 @@ void retro_set_environment(retro_environment_t cb)
       { APPNAME"-skip_disclaimer", "Skip Disclaimer; enabled|disabled" },
       { APPNAME"-skip_warnings", "Skip Warnings; disabled|enabled" },
       { APPNAME"-sample_rate", "Sample Rate (KHz); 48000|8000|11025|22050|44100" },
-      { APPNAME"-external_hiscore", "Use external hiscore.dat; disabled|enabled" },      
       { APPNAME"-dialsharexy", "Share 2 player dial controls across one X/Y device; disabled|enabled" },
 #if defined(__IOS__)
       { APPNAME"-mouse_device", "Mouse Device; pointer|mouse|disabled" },
@@ -324,20 +323,6 @@ static void update_variables(void)
       options.samplerate = atoi(var.value);
    else
       options.samplerate = 48000;
-
-   var.value = NULL;
-   var.key = APPNAME"-external_hiscore";
-   
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if(strcmp(var.value, "enabled") == 0)
-         options.use_external_hiscore = 1;
-      else
-         options.use_external_hiscore = 0;
-   }
-   else
-      options.use_external_hiscore = 0;  
-
 
    var.value = NULL;
    

--- a/src/mame.h
+++ b/src/mame.h
@@ -191,7 +191,6 @@ struct GameOptions
 
 	int		 samplerate;		    /* sound sample playback rate, in KHz */
 	int		 use_samples;	        /* 1 to enable external .wav samples */
-    unsigned use_external_hiscore;  /* 1 to load hiscore.dat from the libretro system folder structure rather than the compiled core */
 
 	float	 brightness;		    /* brightness of the display */
 	float	 pause_bright;		    /* additional brightness when in pause */


### PR DESCRIPTION
And if there isn't one present, one is generated. This is the behavior in 2003-plus