### PR TITLE
Correct way to compare string

### DIFF
--- a/src/sndhrdw/astrocde_sndhrdw.c
+++ b/src/sndhrdw/astrocde_sndhrdw.c
@@ -145,7 +145,7 @@ READ_HANDLER( wow_speech_r )
 				totalword[0] = 0;				   /* Clear the total word stack */
 				return data;
 	}
-	if (PhonemeTable[Phoneme] == "PA0")						   /* We know PA0 is never part of a word */
+	if (strcmp(PhonemeTable[Phoneme], "PA0")==0)						   /* We know PA0 is never part of a word */
 				totalword[0] = 0;				   /* Clear the total word stack */
 
 /* Phoneme to word translation */


### PR DESCRIPTION
This line cause errors in compiler checking. https://build.opensuse.org/package/live_build_log/Emulators/libretro-mame2003/openSUSE_Leap_15.1/x86_64

I followed this https://www.wikihow.com/Compare-Two-Strings-in-C-Programming

---

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
