### PR TITLE
It is only copied to memory after successful reading, preventing the …

### DIFF
--- a/src/hiscore.c
+++ b/src/hiscore.c
@@ -181,8 +181,10 @@ static void hs_load (void)
 					enough to be dynamically allocated, but let's
 					avoid memory trashing just in case
 				*/
-				mame_fread (f, data, mem_range->num_bytes);
-				copy_to_memory (mem_range->cpu, mem_range->addr, data, mem_range->num_bytes);
+				if (mem_range->num_bytes == mame_fread (f, data, mem_range->num_bytes))
+				{
+					copy_to_memory (mem_range->cpu, mem_range->addr, data, mem_range->num_bytes);
+				}
 				free (data);
 			}
 			mem_range = mem_range->next;


### PR DESCRIPTION
For example: 
invadpt2, generate a 0-byte invadpt2.hi, run the emulator at this time, the position of hiscore will display garbled characters