### PR TITLE
Workaround invalid rotate code

### DIFF
--- a/src/drivers/snk.c
+++ b/src/drivers/snk.c
@@ -314,40 +314,40 @@ static int snk_rot12( int which ){
 	static int dial_select[2];
 
 	/* added to compensate for Guerilla War bug fix noted above.
-        ** When dial_select is used to point to invalid 0xf0 (when set to 6),
-        ** in the frame after dial select was set to 6,
-        ** move to the next valid setting in the rotation
-        ** the character was supposed to rotate to, 5 or 7
-        ** which is used to point to 0x50 or 0x60 in dial_12.
-        */
-        if ( dial_select[which] == 6 ){
-                if ( old_dial_select[which] < dial_select[which] ){
-                        old_dial_select[which] = dial_select[which];
-                        dial_select[which]++;
-                }
-                else {
-                        old_dial_select[which] = dial_select[which];
-                        dial_select[which]--;
-                }
-        }
-        else {
-                int delta = (joydir - old_joydir[which])&0xf;
-                old_joydir[which] = joydir;
-                if( delta<=7 && delta>=1 ){
-                        if( dial_select[which]==12 ) dial_select[which] = 0;
-                        else {
-                                old_dial_select[which] = dial_select[which];
-                                dial_select[which]++;
-                        }
-                }
-                else if( delta > 8 ){
-                        if( dial_select[which]==0 ) dial_select[which] = 12;
-                        else {
-                                old_dial_select[which] = dial_select[which];
-                                dial_select[which]--;
-                        }
-                }
-        }
+	** When dial_select is used to point to invalid 0xf0 (when set to 6),
+	** in the frame after dial select was set to 6,
+	** move to the next valid setting in the rotation
+	** the character was supposed to rotate to, 5 or 7
+	** which is used to point to 0x50 or 0x60 in dial_12.
+	*/
+	if ( dial_select[which] == 6 ){
+		if ( old_dial_select[which] < dial_select[which] ){
+			old_dial_select[which] = dial_select[which];
+			dial_select[which]++;
+		}
+		else {
+			old_dial_select[which] = dial_select[which];
+			dial_select[which]--;
+		}
+	}
+	else {
+		int delta = (joydir - old_joydir[which])&0xf;
+		old_joydir[which] = joydir;
+		if( delta<=7 && delta>=1 ){
+			if( dial_select[which]==12 ) dial_select[which] = 0;
+			else {
+				old_dial_select[which] = dial_select[which];
+				dial_select[which]++;
+			}
+		}
+		else if( delta > 8 ){
+			if( dial_select[which]==0 ) dial_select[which] = 12;
+			else {
+				old_dial_select[which] = dial_select[which];
+				dial_select[which]--;
+			}
+		}
+	}
 
 	return (value&0xf) | dial_12[dial_select[which]];
 }

--- a/src/drivers/snk.c
+++ b/src/drivers/snk.c
@@ -310,19 +310,44 @@ static int snk_rot12( int which ){
 	int value = readinputport(which+1);
 	int joydir = value>>4;
 	static int old_joydir[2];
+	static int old_dial_select[2];
 	static int dial_select[2];
 
-	int delta = (joydir - old_joydir[which])&0xf;
-	old_joydir[which] = joydir;
-
-	if( delta<=7 && delta>=1 ){
-		if( dial_select[which]==12 ) dial_select[which] = 0;
-		else dial_select[which]++;
-	}
-	else if( delta > 8 ){
-		if( dial_select[which]==0 ) dial_select[which] = 12;
-		else dial_select[which]--;
-	}
+	/* added to compensate for Guerilla War bug fix noted above.
+        ** When dial_select is used to point to invalid 0xf0 (when set to 6),
+        ** in the frame after dial select was set to 6,
+        ** move to the next valid setting in the rotation
+        ** the character was supposed to rotate to, 5 or 7
+        ** which is used to point to 0x50 or 0x60 in dial_12.
+        */
+        if ( dial_select[which] == 6 ){
+                if ( old_dial_select[which] < dial_select[which] ){
+                        old_dial_select[which] = dial_select[which];
+                        dial_select[which]++;
+                }
+                else {
+                        old_dial_select[which] = dial_select[which];
+                        dial_select[which]--;
+                }
+        }
+        else {
+                int delta = (joydir - old_joydir[which])&0xf;
+                old_joydir[which] = joydir;
+                if( delta<=7 && delta>=1 ){
+                        if( dial_select[which]==12 ) dial_select[which] = 0;
+                        else {
+                                old_dial_select[which] = dial_select[which];
+                                dial_select[which]++;
+                        }
+                }
+                else if( delta > 8 ){
+                        if( dial_select[which]==0 ) dial_select[which] = 12;
+                        else {
+                                old_dial_select[which] = dial_select[which];
+                                dial_select[which]--;
+                        }
+                }
+        }
 
 	return (value&0xf) | dial_12[dial_select[which]];
 }


### PR DESCRIPTION
@mahoneyt944 

Hi, thanks for getting back to me and offering to review.  Here is the patch for the issue submitted as a pull request as directed.  I have also pasted what I posted in the issue here below.  Let me know if there are questions.
-----
I investigated this, and it looks like this issue is caused by a bug fix which intentionally feeds a invalid code to avoid a bug with Guerilla War.

I also came up with a patch (now this pull request) that automatically rotates to the next code (which is a good code) that the character was rotating to in the next frame.  So, the bug fix for Guerilla war still works, but the user never perceives the character did not rotate when the 12 way joystick is rotated.

Let me know if there are issues with the patch, method of fixing this bug, etc.  I'm willing to correct as needed.

Reference:
Some code in src/drivers/snk.c intentionally introducing the invalid code (0xf0):
```
        const int dial_12[13] = {
        0xb0,0xa0,0x90,0x80,0x70,0x60,
        0xf0,
        /* 0xf0 isn't a valid direction, but avoids the "joystick error"
        protection
        ** in Guerilla War which happens when direction changes directly from
        ** 0x50<->0x60 8 times.
        */
        0x50,0x40,0x30,0x20,0x10,0x00
        };
```
[patchSNKFixRotate.txt](https://github.com/libretro/mame2003-libretro/files/12776491/patchSNKFixRotate.txt)


Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
