### PR TITLE
Fix Analog Port initial default so Time Soldiers / Battlefield charac…

### DIFF
--- a/src/drivers/alpha68k.c
+++ b/src/drivers/alpha68k.c
@@ -1130,10 +1130,12 @@ INPUT_PORTS_START( timesold )
 	PORT_BIT( 0xc0, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START  /* player 1 12-way rotary control - converted in controls_r() */
-	PORT_ANALOGX( 0xff, 0x00, IPT_DIAL | IPF_REVERSE, 25, 8, 0, 0, KEYCODE_Z, KEYCODE_X, IP_JOY_NONE, IP_JOY_NONE )
+  /* 0xf5 default represents in the middle of the port range for the character pointing straight up */
+	PORT_ANALOGX( 0xff, 0xf5, IPT_DIAL | IPF_REVERSE, 25, 8, 0, 0, KEYCODE_Z, KEYCODE_X, IP_JOY_NONE, IP_JOY_NONE )
 
 	PORT_START  /* player 2 12-way rotary control - converted in controls_r() */
-	PORT_ANALOGX( 0xff, 0x00, IPT_DIAL | IPF_REVERSE | IPF_PLAYER2, 25, 8, 0, 0, KEYCODE_N, KEYCODE_M, IP_JOY_NONE, IP_JOY_NONE )
+  /* 0xf5 default represents in the middle of the port range for the character pointing straight up */
+	PORT_ANALOGX( 0xff, 0xf5, IPT_DIAL | IPF_REVERSE | IPF_PLAYER2, 25, 8, 0, 0, KEYCODE_N, KEYCODE_M, IP_JOY_NONE, IP_JOY_NONE )
 INPUT_PORTS_END
 
 /* Same as 'timesold' but different default settings for the "Language" Dip Switch */
@@ -1184,10 +1186,12 @@ INPUT_PORTS_START( btlfield )
 	PORT_BIT( 0xc0, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START  /* player 1 12-way rotary control - converted in controls_r() */
-	PORT_ANALOGX( 0xff, 0x00, IPT_DIAL | IPF_REVERSE, 25, 8, 0, 0, KEYCODE_Z, KEYCODE_X, IP_JOY_NONE, IP_JOY_NONE )
+  /* 0xf5 default represents in the middle of the port range for the character pointing straight up */
+	PORT_ANALOGX( 0xff, 0xf5, IPT_DIAL | IPF_REVERSE, 25, 8, 0, 0, KEYCODE_Z, KEYCODE_X, IP_JOY_NONE, IP_JOY_NONE )
 
 	PORT_START  /* player 2 12-way rotary control - converted in controls_r() */
-	PORT_ANALOGX( 0xff, 0x00, IPT_DIAL | IPF_REVERSE | IPF_PLAYER2, 25, 8, 0, 0, KEYCODE_N, KEYCODE_M, IP_JOY_NONE, IP_JOY_NONE )
+  /* 0xf5 default represents in the middle of the port range for the character pointing straight up */
+	PORT_ANALOGX( 0xff, 0xf5, IPT_DIAL | IPF_REVERSE | IPF_PLAYER2, 25, 8, 0, 0, KEYCODE_N, KEYCODE_M, IP_JOY_NONE, IP_JOY_NONE )
 INPUT_PORTS_END
 
 INPUT_PORTS_START( skysoldr )


### PR DESCRIPTION
…ter is correctly pointing straight up.
Hi @mahoneyt944 

Exactly per https://github.com/libretro/mame2003-plus-libretro/pull/1743 for mame2003-plus , this just changes for mame2003 the initial default value of the analog port so the character is pointing up and the value is at the midpoint of the value range for pointing up.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
