### PR TITLE
Avoid multiple detect from single12way rotate

### DIFF
--- a/src/inptport.c
+++ b/src/inptport.c
@@ -7,17 +7,17 @@
 TODO:	remove the 1 analog device per port limitation
 		support for inputports producing interrupts
 		support for extra "real" hardware (PC throttle's, spinners etc)
-		
+
                  Controller-Specific Input Port Mappings
                  ---------------------------------------
 
-The main purpose of the controller-specific configuration is to remap 
-inputs.  This is handled via two mechanisms: key re-mapping and 
+The main purpose of the controller-specific configuration is to remap
+inputs.  This is handled via two mechanisms: key re-mapping and
 sequence re-mapping.
 
 Key re-mapping occurs at the most basic level.  The specified keycode is
-replaced where ever it occurs (in all sequences) with the specified 
-replacement.  Only single keycodes can be used as a replacement (that is, a 
+replaced where ever it occurs (in all sequences) with the specified
+replacement.  Only single keycodes can be used as a replacement (that is, a
 single key cannot be replaced with a key sequence).
 
 Sequence mapping occurs at a higher level.  In this case, the entire
@@ -27,15 +27,15 @@ sequence.
 Keycodes are specified as a single keyword.  Key sequences are specified
 as a series of keycodes separated by spaces (the full sequence must be
 enclosed in quotes if spaces exist).  Two special keywords are available
-for defining key sequences, CODE_OR and CODE_NOT (which can abbreviated | 
+for defining key sequences, CODE_OR and CODE_NOT (which can abbreviated |
 and ! respectively).
 
 When two keycodes are specified together (separated by only whitespace),
 the default action is a logical AND, such that both keys must be pressed
 at the same time for the action to occur.  Often it desired that either
-key can be pressed for the action to occur (for example LEFT CTRL and 
+key can be pressed for the action to occur (for example LEFT CTRL and
 Joystick Button 0), in which case the two keycodes need to be separated
-by a CODE_OR (|) keyword.  Finally, certain combinations may be 
+by a CODE_OR (|) keyword.  Finally, certain combinations may be
 undesirable and warrant no action by MAME.  For these, the keywords should
 be specified by a CODE_NOT (!) (for example, ALT-TAB on a windows machine).
 
@@ -57,9 +57,9 @@ Specifies the directory that contains the controller customization .ini files.
 
 -ctrlr "name"
 
-Specifies a controller name for customization.  The .ini files for the 
+Specifies a controller name for customization.  The .ini files for the
 controller are stored in either a directory or a .zip file with the same
-name as the specified controller.  
+name as the specified controller.
 
 The first file in the directory/zip to be scanned is the file default.ini.
 From there, game-specific files are scanned starting with the top-most
@@ -85,12 +85,12 @@ enabled on those games that require it.  If all games for this controller
 require joystick and/or mouse support, those keywords can be placed in
 the main default.ini file.
 
-All of the options that can be specified on the command-line or in the 
-main mame.ini file can be specified in the controller-specific ini files, 
-though because of when these files are parsed, the specified options may 
+All of the options that can be specified on the command-line or in the
+main mame.ini file can be specified in the controller-specific ini files,
+though because of when these files are parsed, the specified options may
 have no effect.  The only two general options guaranteed to be supported
 are mouse and joystick.  Note that command-line specification of these
-options takes precedence.  Since most front-ends, including MAME32, 
+options takes precedence.  Since most front-ends, including MAME32,
 specify these options through the command-line, the mouse and/or joystick
 options specified in the .ini files will be ignored.
 
@@ -98,7 +98,7 @@ Another custom keyword is:
 
 ctrlrname               "name"
 
-This keyword defines a detailed name for the selected controller.  Names 
+This keyword defines a detailed name for the selected controller.  Names
 that include spaces must be enclosed in quotes.
 
 
@@ -107,8 +107,8 @@ Keywords:
 
 Keywords are separated into two categories, keycodes and input port
 definitions.  To specify a key re-mapping, specify the keycode as the
-keyword to re-define (that is, on the left-hand side) followed by the 
-replacement code.  To specify a sequence re-map, specify the input port 
+keyword to re-define (that is, on the left-hand side) followed by the
+replacement code.  To specify a sequence re-map, specify the input port
 code to be re-defined on the left followed by the sequence.
 
 In addition to the standard codes, additional OSD specific codes may be
@@ -131,8 +131,8 @@ connected.  In the codes listed above, the Wingman Warrior was connected as
 the first joystick (J1).  If it had been configured as a different input,
 the generated codes would have a different Jx number.
 
-All keyword matching including the standard keywords is case sensitive.  
-Also, some of the automatically generated OSD codes may be redundant. 
+All keyword matching including the standard keywords is case sensitive.
+Also, some of the automatically generated OSD codes may be redundant.
 For example, J1_Button_0 is the same as JOYCODE_1_BUTTON1.  Standard codes
 are preferred over OSD codes.
 
@@ -240,15 +240,15 @@ P2_JOYSTICKLEFT_RIGHT
 
 P3_JOYSTICK_UP           P3_JOYSTICK_DOWN         P3_JOYSTICK_LEFT
 P3_JOYSTICK_RIGHT        P3_BUTTON1               P3_BUTTON2
-P3_BUTTON3               P3_BUTTON4               
+P3_BUTTON3               P3_BUTTON4
 
 P4_JOYSTICK_UP           P4_JOYSTICK_DOWN         P4_JOYSTICK_LEFT
 P4_JOYSTICK_RIGHT        P4_BUTTON1               P4_BUTTON2
-P4_BUTTON3               P4_BUTTON4               
+P4_BUTTON3               P4_BUTTON4
 
 P1_PEDAL                 P1_PEDAL_EXT             P2_PEDAL
 P2_PEDAL_EXT             P3_PEDAL                 P3_PEDAL_EXT
-P4_PEDAL                 P4_PEDAL_EXT             
+P4_PEDAL                 P4_PEDAL_EXT
 
 P1_PADDLE                P1_PADDLE_EXT            P2_PADDLE
 P2_PADDLE_EXT            P3_PADDLE                P3_PADDLE_EXT
@@ -266,19 +266,19 @@ P4_DIAL_V_EXT
 
 P1_TRACKBALL_X           P1_TRACKBALL_X_EXT       P2_TRACKBALL_X
 P2_TRACKBALL_X_EXT       P3_TRACKBALL_X           P3_TRACKBALL_X_EXT
-P4_TRACKBALL_X           P4_TRACKBALL_X_EXT       
+P4_TRACKBALL_X           P4_TRACKBALL_X_EXT
 
 P1_TRACKBALL_Y           P1_TRACKBALL_Y_EXT       P2_TRACKBALL_Y
 P2_TRACKBALL_Y_EXT       P3_TRACKBALL_Y           P3_TRACKBALL_Y_EXT
-P4_TRACKBALL_Y           P4_TRACKBALL_Y_EXT       
+P4_TRACKBALL_Y           P4_TRACKBALL_Y_EXT
 
 P1_AD_STICK_X            P1_AD_STICK_X_EXT        P2_AD_STICK_X
 P2_AD_STICK_X_EXT        P3_AD_STICK_X            P3_AD_STICK_X_EXT
-P4_AD_STICK_X            P4_AD_STICK_X_EXT        
+P4_AD_STICK_X            P4_AD_STICK_X_EXT
 
 P1_AD_STICK_Y            P1_AD_STICK_Y_EXT        P2_AD_STICK_Y
 P2_AD_STICK_Y_EXT        P3_AD_STICK_Y            P3_AD_STICK_Y_EXT
-P4_AD_STICK_Y            P4_AD_STICK_Y_EXT        
+P4_AD_STICK_Y            P4_AD_STICK_Y_EXT
 
 OSD_1                    OSD_2                    OSD_3
 OSD_4
@@ -290,6 +290,7 @@ OSD_4
 #include <math.h>
 #include "driver.h"
 #include "config.h"
+#include "cpuexec.h"
 
 
 /***************************************************************************
@@ -1673,7 +1674,7 @@ static void load_default_keys(void)
 		config_read_default_ports(cfg, inputport_defaults);
 		config_close(cfg);
 	}
-  
+
   osd_customize_inputport_defaults(inputport_defaults);
 }
 
@@ -1691,9 +1692,9 @@ static void save_default_keys(void)
 	memcpy(inputport_defaults,inputport_defaults_backup,sizeof(inputport_defaults_backup));
 }
 
-/* 
+/*
  * void reset_default_inputs(void)
- * repopulate mappings from the defaults specified in the inptport source 
+ * repopulate mappings from the defaults specified in the inptport source
  */
 void reset_default_inputs(void)
 {
@@ -1701,9 +1702,9 @@ void reset_default_inputs(void)
   save_default_keys();
 }
 
-/* 
+/*
  * void reset_default_inputs(void)
- * repopulate mappings from the defaults specified in the driver source 
+ * repopulate mappings from the defaults specified in the driver source
  */
 void reset_driver_inputs(void)
 {
@@ -1871,6 +1872,9 @@ void update_analog_port(int port)
 	InputSeq* decseq;
 	int keydelta;
 	int player;
+  int xwayjoy;
+  int last_frame;
+  static int last_frame_inc = 0, last_frame_dec = 0;
 
 	/* get input definition */
 	in = input_analog[port];
@@ -1942,7 +1946,7 @@ void update_analog_port(int port)
 	delta = 0;
 
 	player = IP_GET_PLAYER(in);
-    
+
     /* if second player on a dial, and dial sharing turned on, use Y axis from player 1 */
     if (options.dial_share_xy && type == IPT_DIAL && player == 1)
     {
@@ -1952,11 +1956,30 @@ void update_analog_port(int port)
 
 	delta = mouse_delta_axis[player][axis];
 
-	if (seq_pressed(decseq)) delta -= keydelta;
+  xwayjoy = (in+2)->type & IPF_XWAYJOY;
+  last_frame = cpu_getcurrentframe() - 1;
+
+	if (seq_pressed(decseq))
+    /* Don't register button press if xwayjoy is on, is DIAL(_V) type, and button was pressed last frame */
+    if (  !(    (xwayjoy == IPF_XWAYJOY)
+        && ((type == IPT_DIAL) || (type == IPT_DIAL_V))
+        && (last_frame == last_frame_dec)   )  )
+    {
+      delta -= keydelta;
+      last_frame_dec = last_frame + 1;
+    }
 
 	if (type != IPT_PEDAL && type != IPT_PEDAL2)
 	{
-		if (seq_pressed(incseq)) delta += keydelta;
+		if (seq_pressed(incseq))
+      /* Don't register button press if xwayjoy is on, is DIAL(_V) type, and button was pressed last frame */
+      if (  !(    (xwayjoy == IPF_XWAYJOY)
+          && ((type == IPT_DIAL) || (type == IPT_DIAL_V))
+          && (last_frame == last_frame_inc)   )  )
+      {
+        delta += keydelta;
+        last_frame_inc = last_frame + 1;
+      }
 	}
 	else
 	{
@@ -2250,19 +2273,19 @@ ScanJoysticks( struct InputPort *in )
 			  }
 
 		}
-    else if (options.restrict_4_way) //start use alternative code 
+    else if (options.restrict_4_way) //start use alternative code
     {
       if(options.content_flags[CONTENT_ROTATE_JOY_45])
       {
         if  ( (mJoyCurrent[i]) && (mJoyCurrent[i] !=1) &&
               (mJoyCurrent[i] !=2) && (mJoyCurrent[i] !=4) &&
-              (mJoyCurrent[i] !=8) )  	
-        {    
+              (mJoyCurrent[i] !=8) )
+        {
           if      (mJoyCurrent[i] == 9)  mJoy4Way[i]=1;
           else if (mJoyCurrent[i] == 6)  mJoy4Way[i]=2;
           else if (mJoyCurrent[i] == 5)  mJoy4Way[i]=4;
           else if (mJoyCurrent[i] == 10) mJoy4Way[i]=8;
-        }     
+        }
         else if (mJoy4Way[i])
           mJoy4Way[i]=0;
       }
@@ -2679,7 +2702,13 @@ struct InputPort* input_port_allocate(const struct InputPortTiny *src)
 		InputCode seq_default;
 
 		if (type > IPT_ANALOG_START && type < IPT_ANALOG_END)
-			src_end = src + 2;
+    {
+      if ((type == IPT_DIAL) || (type == IPT_DIAL_V))
+        /* third port stores additional data */
+        src_end = src + 3;
+      else
+			  src_end = src + 2;
+    }
 		else
 			src_end = src + 1;
 

--- a/src/inptport.h
+++ b/src/inptport.h
@@ -156,6 +156,8 @@ enum { IPT_END=1,IPT_PORT,
 
 #define IPF_RESETCPU   0x02000000	/* when the key is pressed, reset the first CPU */
 
+#define IPF_XWAYJOY    0x04000000 /* block detected analog key/joy just pressed for one frame */
+#define IPF_XWAYJOY_OFF    0x00000000 /* xwayjoy set to off */
 
 /* The "arg" field contains 4 bytes fields */
 #define IPF_SENSITIVITY(percent)	((percent & 0xff) << 8)
@@ -218,13 +220,17 @@ enum { IPT_END=1,IPT_PORT,
 /* analog input */
 #define PORT_ANALOG(mask,default,type,sensitivity,delta,min,max) \
 	PORT_BIT(mask, default, type) \
-	{ min, max, IPT_EXTENSION | IPF_SENSITIVITY(sensitivity) | IPF_DELTA(delta), IP_NAME_DEFAULT },
+	{ min, max, IPT_EXTENSION | IPF_SENSITIVITY(sensitivity) | IPF_DELTA(delta), IP_NAME_DEFAULT }, \
+  { 0, 0, IPF_XWAYJOY_OFF, IP_NAME_DEFAULT },
+/* Both zeros above are not used */
 
 #define PORT_ANALOGX(mask,default,type,sensitivity,delta,min,max,keydec,keyinc,joydec,joyinc) \
 	PORT_BIT(mask, default, type) \
 	{ min, max, IPT_EXTENSION | IPF_SENSITIVITY(sensitivity) | IPF_DELTA(delta), IP_NAME_DEFAULT }, \
+  { 0, 0, IPF_XWAYJOY_OFF, IP_NAME_DEFAULT }, \
 	PORT_CODE(keydec,joydec) \
 	PORT_CODE(keyinc,joyinc)
+/* Both zeros above are not used */
 
 /* dip switch definition */
 #define PORT_DIPNAME(mask,default,name) \
@@ -244,7 +250,7 @@ enum { IPT_END=1,IPT_PORT,
 
 #define MAX_DEFSTR_LEN 20
 extern const char ipdn_defaultstrings[][MAX_DEFSTR_LEN];
-#define PORT_ADJUSTER(default,name) 
+#define PORT_ADJUSTER(default,name)
 
 /* this must match the ipdn_defaultstrings list in inptport.c */
 enum {
@@ -412,15 +418,15 @@ extern int num_ik;
 void seq_set_string(InputSeq* a, const char *buf);
 const char *generic_ctrl_label(int input);
 
-/* 
+/*
  * void reset_default_inputs(void)
- * repopulate mappings from the defaults specified in the inptport source 
+ * repopulate mappings from the defaults specified in the inptport source
  */
 void reset_default_inputs(void);
 
-/* 
+/*
  * void reset_default_keys(void)
- * repopulate mappings from the defaults specified in the driver source 
+ * repopulate mappings from the defaults specified in the driver source
  */
 void reset_driver_inputs(void);
 

--- a/src/ui_text.c
+++ b/src/ui_text.c
@@ -80,11 +80,11 @@ static const char *mame_default_text[] =
 	"Bookkeeping Info",
 	"Input (this game)",
   "Flush Current CFG",
-  "Flush All CFGs",  
+  "Flush All CFGs",
 	"Game Information",
 	"Game History",
 	"Reset Game",
-  "Generate XML DAT",  
+  "Generate XML DAT",
 	"Return to Game",
 	"Cheat",
 	"Memory Card",
@@ -93,6 +93,7 @@ static const char *mame_default_text[] =
 	"Key/Joy Speed",
 	"Reverse",
 	"Sensitivity",
+  "X-Way Joystick",
 
 	/* stats */
 	"Tickets dispensed",

--- a/src/ui_text.h
+++ b/src/ui_text.h
@@ -79,11 +79,11 @@ enum
 	UI_bookkeeping,
 	UI_inputspecific,
   UI_flush_current_cfg,
-  UI_flush_all_cfg,  
+  UI_flush_all_cfg,
 	UI_gameinfo,
 	UI_history,
   UI_resetgame,
-  UI_generate_xml_dat,  
+  UI_generate_xml_dat,
 	UI_returntogame,
 	UI_cheat,
 	UI_memorycard,
@@ -92,6 +92,7 @@ enum
 	UI_keyjoyspeed,
 	UI_reverse,
 	UI_sensitivity,
+  UI_xwayjoy,
 
 	/* stats */
 	UI_tickets,

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -1771,8 +1771,8 @@ static int setcodesettings(struct mame_bitmap *bitmap,int selected)
 	total = 0;
 	while (in->type != IPT_END)
 	{
-		if (input_port_name(in) != 0 && seq_get_1(&in->seq) != CODE_NONE && (in->type & ~IPF_MASK) != IPT_UNKNOWN && (in->type & ~IPF_MASK) != IPT_OSD_DESCRIPTION 
-		 && !( !options.cheat_input_ports && (in->type & IPF_CHEAT) ) ) 	
+		if (input_port_name(in) != 0 && seq_get_1(&in->seq) != CODE_NONE && (in->type & ~IPF_MASK) != IPT_UNKNOWN && (in->type & ~IPF_MASK) != IPT_OSD_DESCRIPTION
+		 && !( !options.cheat_input_ports && (in->type & IPF_CHEAT) ) )
 		{
 			entry[total] = in;
 			menu_item[total] = input_port_name(in);
@@ -1948,6 +1948,8 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 	const char *menu_item[40];
 	const char *menu_subitem[40];
 	struct InputPort *entry[40];
+  int entries_per_port[40];
+  int current_port, total_entries_to_current_port;
 	int i,sel;
 	struct InputPort *in;
 	int total,total2;
@@ -1962,14 +1964,27 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 
 	in = Machine->input_ports;
 
+  /* Each analog control has 3 or 4 entries - key & joy delta, reverse, sensitivity, */
+  /* and xwayjoy for IPT_DIAL and IPT_DIAL_V devices */
+
+#define ENTRIES 4
+
 	/* Count the total number of analog controls */
 	total = 0;
+  total2 = 0;
 	while (in->type != IPT_END)
 	{
 		if (((in->type & 0xff) > IPT_ANALOG_START) && ((in->type & 0xff) < IPT_ANALOG_END)
 				&& !(!options.cheat_input_ports && (in->type & IPF_CHEAT)))
 		{
 			entry[total] = in;
+      if (((in->type & 0xff) == IPT_DIAL) || ((in->type & 0xff) == IPT_DIAL_V))
+        entries_per_port[total] = ENTRIES;
+      else
+        entries_per_port[total] = ENTRIES - 1;
+
+      /* Add on entries from this port to get total entries */
+      total2 += entries_per_port[total];
 			total++;
 		}
 		in++;
@@ -1977,17 +1992,13 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 
 	if (total == 0) return 0;
 
-	/* Each analog control has 3 entries - key & joy delta, reverse, sensitivity */
-
-#define ENTRIES 3
-
-	total2 = total * ENTRIES;
-
 	menu_item[total2] = ui_getstring (UI_returntomain);
 	menu_item[total2 + 1] = 0;	/* terminate array */
 	total2++;
 
 	arrowize = 0;
+  current_port = 0;
+  total_entries_to_current_port = 0;  /* Sum of all entries upto, but not including the current port */
 	for (i = 0;i < total2;i++)
 	{
 		if (i < total2 - 1)
@@ -1996,14 +2007,24 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 			char setting[30][40];
 			int sensitivity,delta;
 			int reverse;
+      int xwayjoy;  /* Toggle lock out analog (de)increment for one frame if dial(-v) button just pressed */
 
-			strcpy (label[i], input_port_name(entry[i/ENTRIES]));
-			sensitivity = IP_GET_SENSITIVITY(entry[i/ENTRIES]);
-			delta = IP_GET_DELTA(entry[i/ENTRIES]);
-			reverse = (entry[i/ENTRIES]->type & IPF_REVERSE);
+      /* Determine the current port and total entries upto, but not including the current port are */
+      /* for the current value of i */
+      if (i >= total_entries_to_current_port + entries_per_port[current_port])
+      {
+        total_entries_to_current_port += entries_per_port[current_port];
+        current_port++;
+      }
+
+			strcpy (label[i], input_port_name(entry[current_port]));
+			sensitivity = IP_GET_SENSITIVITY(entry[current_port]);
+			delta = IP_GET_DELTA(entry[current_port]);
+			reverse = (entry[current_port]->type & IPF_REVERSE);
+      xwayjoy = ((entry[current_port]+2)->type & IPF_XWAYJOY);
 
 			strcat (label[i], " ");
-			switch (i%ENTRIES)
+      switch (i - total_entries_to_current_port)
 			{
 				case 0:
 					strcat (label[i], ui_getstring (UI_keyjoyspeed));
@@ -2023,6 +2044,16 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 					sprintf(setting[i],"%3d%%",sensitivity);
 					if (i == sel) arrowize = 3;
 					break;
+        /* This case is not reached for analog devices that are not IPT_DIAL or IPT_DIAL_V */
+        /* Omitting cases for certain analog devices only works for cases at the end per the current code */
+        case 3:
+          strcat (label[i], ui_getstring (UI_xwayjoy));
+          if (xwayjoy)
+            strcpy(setting[i],ui_getstring (UI_on));
+          else
+            strcpy(setting[i],ui_getstring (UI_off));
+          if (i == sel) arrowize = 3;
+          break;
 			}
 
 			menu_item[i] = label[i];
@@ -2045,35 +2076,60 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 	{
 		if(sel != total2 - 1)
 		{
-			if ((sel % ENTRIES) == 0)
+      /* Determine which entry sel is pointing toward */
+      current_port = 0;
+      total_entries_to_current_port = 0;  /* Sum of all entries upto, but not including the current port */
+
+      /* Determine the current port and total entries upto, but not including the current port are */
+      /* for the current value of sel */
+      while (sel - entries_per_port[current_port] >= total_entries_to_current_port)
+      {
+        total_entries_to_current_port += entries_per_port[current_port];
+        current_port++;
+      }
+
+      if ((sel - total_entries_to_current_port) == 0)
 			/* keyboard/joystick delta */
 			{
-				int val = IP_GET_DELTA(entry[sel/ENTRIES]);
+				int val = IP_GET_DELTA(entry[current_port]);
 
 				val --;
 				if (val < 1) val = 1;
-				IP_SET_DELTA(entry[sel/ENTRIES],val);
+				IP_SET_DELTA(entry[current_port],val);
 			}
-			else if ((sel % ENTRIES) == 1)
+			else if ((sel - total_entries_to_current_port) == 1)
 			/* reverse */
 			{
-				int reverse = entry[sel/ENTRIES]->type & IPF_REVERSE;
+				int reverse = entry[current_port]->type & IPF_REVERSE;
 				if (reverse)
 					reverse=0;
 				else
 					reverse=IPF_REVERSE;
-				entry[sel/ENTRIES]->type &= ~IPF_REVERSE;
-				entry[sel/ENTRIES]->type |= reverse;
+				entry[current_port]->type &= ~IPF_REVERSE;
+				entry[current_port]->type |= reverse;
 			}
-			else if ((sel % ENTRIES) == 2)
+			else if ((sel - total_entries_to_current_port) == 2)
 			/* sensitivity */
 			{
-				int val = IP_GET_SENSITIVITY(entry[sel/ENTRIES]);
+				int val = IP_GET_SENSITIVITY(entry[current_port]);
 
 				val --;
 				if (val < 1) val = 1;
-				IP_SET_SENSITIVITY(entry[sel/ENTRIES],val);
+				IP_SET_SENSITIVITY(entry[current_port],val);
 			}
+      /* This case is not reached for analog devices that are not IPT_DIAL or IPT_DIAL_V */
+      /* Omitting cases for certain analog devices only works for cases at the end per the current code */
+      else if ((sel - total_entries_to_current_port) == 3)
+      /* xwayjoy */
+      {
+        int xwayjoy= (entry[current_port]+2)->type & IPF_XWAYJOY;
+        if (xwayjoy)
+          xwayjoy=0;
+        else
+          xwayjoy=IPF_XWAYJOY;
+        (entry[current_port]+2)->type &= ~IPF_XWAYJOY;
+        (entry[current_port]+2)->type |= xwayjoy;
+      }
 		}
 	}
 
@@ -2081,35 +2137,55 @@ static int settraksettings(struct mame_bitmap *bitmap,int selected)
 	{
 		if(sel != total2 - 1)
 		{
-			if ((sel % ENTRIES) == 0)
+      /* Determine which entry sel is pointing toward */
+      current_port = 0;
+      total_entries_to_current_port = 0;
+      while (sel - entries_per_port[current_port] >= total_entries_to_current_port)
+      {
+        total_entries_to_current_port += entries_per_port[current_port];
+        current_port++;
+      }
+
+			if ((sel - total_entries_to_current_port) == 0)
 			/* keyboard/joystick delta */
 			{
-				int val = IP_GET_DELTA(entry[sel/ENTRIES]);
+				int val = IP_GET_DELTA(entry[current_port]);
 
 				val ++;
 				if (val > 255) val = 255;
-				IP_SET_DELTA(entry[sel/ENTRIES],val);
+				IP_SET_DELTA(entry[current_port],val);
 			}
-			else if ((sel % ENTRIES) == 1)
+			else if ((sel - total_entries_to_current_port) == 1)
 			/* reverse */
 			{
-				int reverse = entry[sel/ENTRIES]->type & IPF_REVERSE;
+				int reverse = entry[current_port]->type & IPF_REVERSE;
 				if (reverse)
 					reverse=0;
 				else
 					reverse=IPF_REVERSE;
-				entry[sel/ENTRIES]->type &= ~IPF_REVERSE;
-				entry[sel/ENTRIES]->type |= reverse;
+				entry[current_port]->type &= ~IPF_REVERSE;
+				entry[current_port]->type |= reverse;
 			}
-			else if ((sel % ENTRIES) == 2)
+			else if ((sel - total_entries_to_current_port) == 2)
 			/* sensitivity */
 			{
-				int val = IP_GET_SENSITIVITY(entry[sel/ENTRIES]);
+				int val = IP_GET_SENSITIVITY(entry[current_port]);
 
 				val ++;
 				if (val > 255) val = 255;
-				IP_SET_SENSITIVITY(entry[sel/ENTRIES],val);
+				IP_SET_SENSITIVITY(entry[current_port],val);
 			}
+      else if ((sel - total_entries_to_current_port) == 3)
+      /* xwayjoy */
+      {
+        int xwayjoy= (entry[current_port]+2)->type & IPF_XWAYJOY;
+        if (xwayjoy)
+          xwayjoy=0;
+        else
+          xwayjoy=IPF_XWAYJOY;
+        (entry[current_port]+2)->type &= ~IPF_XWAYJOY;
+        (entry[current_port]+2)->type |= xwayjoy;
+      }
 		}
 	}
 
@@ -2373,7 +2449,7 @@ void generate_gameinfo(void)
 {
 	int i;
 	char buf2[32];
-  
+
   message_buffer[0] = '\0';
 
 	sprintf(message_buffer,"CONTROLS: %s\n\nGAMEINFO: %s\n%s %s\n\n%s:\n",Machine->gamedrv->ctrl_dat->control_details, Machine->gamedrv->description, Machine->gamedrv->year, Machine->gamedrv->manufacturer,
@@ -2488,7 +2564,7 @@ void ui_copyright_and_warnings(void)
   buffer[0]='\0';
   if(!options.skip_disclaimer)
     snprintf(buffer, MAX_MESSAGE_LENGTH, "%s", ui_getstring(UI_copyright));
-  
+
   if(generate_warning_list())
   {
     log_cb(RETRO_LOG_WARN, LOGPRE "\n\n%s\n", message_buffer); /* log warning list to the console */
@@ -2499,20 +2575,20 @@ void ui_copyright_and_warnings(void)
       snprintf(&buffer[strlen(buffer)], MAX_MESSAGE_LENGTH - strlen(buffer), "%s - %s %s\n\n%s", Machine->gamedrv->description, Machine->gamedrv->year, Machine->gamedrv->manufacturer, message_buffer);
     }
   }
- 
+
   generate_gameinfo();
   log_cb(RETRO_LOG_INFO, LOGPRE "\n\n%s\n", message_buffer);
-  
+
   if(strlen(buffer))
     usrintf_showmessage_secs(8, "%s", buffer);
-  
+
 }
 
 bool generate_warning_list(void)
 {
   int i;
   char buffer[MAX_MESSAGE_LENGTH];
-  
+
   buffer[0] = '\0';
 
 	if (Machine->gamedrv->flags &
@@ -2606,7 +2682,7 @@ bool generate_warning_list(void)
 	}
   if(string_is_empty(buffer))
     return false;
-  
+
   snprintf(message_buffer, MAX_MESSAGE_LENGTH, "Driver Warnings:\n%s", buffer);
 	return true;
 }
@@ -3008,8 +3084,8 @@ void setup_menu_init(void)
   {
 	  menu_item[menu_total] = ui_getstring (UI_inputgeneral);      menu_action[menu_total++] = UI_DEFCODE;
     menu_item[menu_total] = ui_getstring (UI_inputspecific);     menu_action[menu_total++] = UI_CODE;
-    //menu_item[menu_total] = ui_getstring (UI_flush_current_cfg); menu_action[menu_total++] = UI_FLUSH_CURRENT_CFG;    
-    //menu_item[menu_total] = ui_getstring (UI_flush_all_cfg);     menu_action[menu_total++] = UI_FLUSH_ALL_CFG;    
+    //menu_item[menu_total] = ui_getstring (UI_flush_current_cfg); menu_action[menu_total++] = UI_FLUSH_CURRENT_CFG;
+    //menu_item[menu_total] = ui_getstring (UI_flush_all_cfg);     menu_action[menu_total++] = UI_FLUSH_ALL_CFG;
   }
 
 	/* Determine if there are any dip switches */
@@ -3078,7 +3154,7 @@ void setup_menu_init(void)
     menu_item[menu_total] = ui_getstring (UI_generate_xml_dat);   menu_action[menu_total++] = UI_GENERATE_XML_DAT;
 
 #endif
-  if(!options.display_setup) 
+  if(!options.display_setup)
   {
     menu_item[menu_total] = ui_getstring (UI_returntogame); menu_action[menu_total++] = UI_EXIT;
   }
@@ -3090,7 +3166,7 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
 {
 	int sel,res=-1;
 	static int menu_lastselected = 0;
- 
+
   if(generate_DAT)
   {
     print_mame_xml();
@@ -3176,7 +3252,7 @@ static int setup_menu(struct mame_bitmap *bitmap, int selected)
 				schedule_full_refresh();
 				break;
       case UI_GENERATE_XML_DAT:
-          frontend_message_cb("Generating XML DAT", 180);   
+          frontend_message_cb("Generating XML DAT", 180);
           schedule_full_refresh();
           generate_DAT = true;
           break;
@@ -3259,7 +3335,7 @@ void CLIB_DECL usrintf_showmessage_secs(int seconds, const char *text,...)
 int handle_user_interface(struct mame_bitmap *bitmap)
 {
 	DoCheat(bitmap);	/* This must be called once a frame */
-   
+
 	if (setup_selected == 0)
   {
     if(input_ui_pressed(IPT_UI_CONFIGURE))
@@ -3270,7 +3346,7 @@ int handle_user_interface(struct mame_bitmap *bitmap)
     {
       setup_selected = -1;
       setup_via_menu = 1;
-	    setup_menu_init();      
+	    setup_menu_init();
     }
 
       if (setup_active()) cpu_pause(true);
@@ -3280,11 +3356,11 @@ int handle_user_interface(struct mame_bitmap *bitmap)
   {
     setup_selected = 0;
     setup_via_menu = 0;
-    setup_menu_init();       
+    setup_menu_init();
     schedule_full_refresh();
-  }   
+  }
   else if(setup_selected)
-  {  
+  {
     setup_selected = setup_menu(bitmap, setup_selected);
   }
 


### PR DESCRIPTION
Hi @mahoneyt944 ,

This is the same patch that I did for mame2003-plus, adding the "X-Way Joystick" option to the Analog Controls menu only for IPT_DIAL and IPT_DIAL_V devices.  Enabling the X-Way Joystick option eliminates one rotary step of a X-Way rotary joystick from sometimes rotating the character 2 rotary steps.

This basically combines the codes used in these two PRs in mame2003-plus:
https://github.com/libretro/mame2003-plus-libretro/pull/1652
https://github.com/libretro/mame2003-plus-libretro/pull/1740

It has been about two weeks since those PRs settled, and I didn't see anything mentioned in the issues list, so I assume no bugs have been discovered.

Also, question for you.  Is there a good place to put recommended key/joy step, sensitivity, and x-way joystick settings for each of the 15ish or so games that used a x-way rotary joystick?  I figured out what the specific settings that work best for each game with an x-way rotary joystick.  I'd be interested to add that in a blog or faq somewhere so people know about it.  I'd want to add that for mame2003 and mame2003-plus.  If that is not possible, I do plan at the least to send that info to the manufacturer of the 12-way rotary joystick that I have.

Thanks!

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
