### PR TITLE
Added new X-Way Joystick option and Recommended Analog Controls setti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,79 @@ Champion Baseball Japan set 2 [Stefan Jokisch]
 Target Balls [David Haywood]
 	not looked at it much yet, seems to be paradise.c
 
+New and/or Recommended Input Options and Settings
+--------------------------------------------------------------
+
+Added 'X-Way Joystick' Option to Analog Controls Menu only for IPT_DIAL
+and IPT_DIAL_V devices.  This option is for use with x-way rotary joysticks
+(where the joystick can rotate X discrete steps, 8 or 12 appears to be most
+common).  The joystick can still move up, down, left, right and diagonally.
+The most famous game to use this control scheme is Ikari Warriors.
+Notes on this option:
+    * When on, prevents the character from rotating two discrete steps
+    sometimes when the rotary joystick is just rotated one step.
+    * When on, the character will only rotate up to half the frame rate
+    instead of the frame rate, so up to 30 times per second instead of 60
+    times a second if the game is running at 60Hz.
+
+Recommended analog control settings for known games that use an x-way rotary
+joystick to give the intended rotary control of the character. (Note: Settings
+will work best if the game is running at its native 60Hz, and the time
+the rotary joystick "holds" down the virtual IPT_DIAL or IPT_DIAL_V button
+is longer than 1/60th of a second, but less than 2/60ths of a second.):
+    * Bermuda Triangle
+        - Key/Joy Speed: 16
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Caliber 50
+        - Key/Joy Speed: 4
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Downtown
+        - Key/Joy Speed: 22
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Guerrilla War
+        - Key/Joy Speed: 16
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Heavy Barrel
+        - Key/Joy Speed: 21
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Ikari Warriors
+        - Key/Joy Speed: 16
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Victory Road (kind of Ikari Warriors II)
+        - Key/Joy Speed: 16
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Ikari III - The Rescue
+        - Key/Joy Speed: 21
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Midnight Resistance
+        - Key/Joy Speed: 21
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * SAR - Search and Rescue
+        - Key/Joy Speed: 21
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Time Soldiers
+        - Key/Joy Speed: 21
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Touchdown Fever
+        - Key/Joy Speed: 2
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Touchdown Fever 2
+        - Key/Joy Speed: 2
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+
 # 0.77u3
 ------
 


### PR DESCRIPTION
…ngs if using an X-Way rotary joystick for the games that used it in the arcade to the CHANGELOG.md

Hi @mahoneyt944 ,

As suggested in this PR, https://github.com/libretro/mame2003-libretro/pull/514 , I am submitting this new PR to add info on the new X-Way Joystick option and recommended Analog Controls settings if using a x-way rotary joystick to CHANGELOG.md at the end of the 0.78 section.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
