### PR TITLE
Put DownTown rotary initial value to middle of range in rotary step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,8 +239,8 @@ is longer than 1/60th of a second, but less than 2/60ths of a second.):
         - Key/Joy Speed: 4
         - Sensitivity: 100%
         - X-Way Joystick: On
-    * Downtown
-        - Key/Joy Speed: 22
+    * DownTown
+        - Key/Joy Speed: 21
         - Sensitivity: 100%
         - X-Way Joystick: On
     * Guerrilla War

--- a/src/drivers/seta.c
+++ b/src/drivers/seta.c
@@ -2869,8 +2869,8 @@ PORT_END
 	PORT_BIT(  0x0080, IP_ACTIVE_LOW, IPT_START##_n_					)
 
 
-#define JOY_ROTATION(_n_, _left_, _right_ ) \
-	PORT_ANALOGX( 0xff, 0x00, IPT_DIAL | IPF_PLAYER##_n_, 15, 15, 0, 0, KEYCODE_##_left_, KEYCODE_##_right_, IP_JOY_NONE, IP_JOY_NONE )
+#define JOY_ROTATION(_n_, _left_, _right_, _default_ ) \
+	PORT_ANALOGX( 0xff, _default_, IPT_DIAL | IPF_PLAYER##_n_, 15, 15, 0, 0, KEYCODE_##_left_, KEYCODE_##_right_, IP_JOY_NONE, IP_JOY_NONE )
 
 
 
@@ -3232,10 +3232,10 @@ INPUT_PORTS_START( calibr50 )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 
 	PORT_START	// IN4 - Rotation Player 1
-	JOY_ROTATION(1, Z, X)
+	JOY_ROTATION(1, Z, X, 0x00)
 
 	PORT_START	// IN5 - Rotation Player 2
-	JOY_ROTATION(2, N, M)
+	JOY_ROTATION(2, N, M, 0x00)
 INPUT_PORTS_END
 
 /***************************************************************************
@@ -3479,10 +3479,10 @@ INPUT_PORTS_START( downtown )
 	PORT_DIPSETTING(      0x0000, "2" )
 
 	PORT_START	// IN4 - Rotation Player 1
-	JOY_ROTATION(1, Z, X)
+	JOY_ROTATION(1, Z, X, 0x0a)
 
 	PORT_START	// IN5 - Rotation Player 2
-	JOY_ROTATION(1, N, M)
+	JOY_ROTATION(1, N, M, 0x0a)
 INPUT_PORTS_END
 
 


### PR DESCRIPTION
Hi @mahoneyt944 ,

This PR does the same thing as this mame2003-plus PR that I submitted a day or two ago:  https://github.com/libretro/mame2003-plus-libretro/pull/1765

Relisting those changes here:

- Adjust the default (initial) value of the Dial Analog Port for the game DownTown to put it in the middle of the range of the rotary step. This keeps precession from causing the character to lose or gain an extra step for about 30 twists continuously in one direction (for both directions).
- - by modifying the JOY_ROTATION macro (which generates the PORT_ANALOGX macro for Caliber 50 and DownTown keeping the default value of Caliber 50 the same, and changing the default value of DownTown
- Changed recommended key/joy step for DownTown to make it work the best with this change

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
