### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ else ifeq ($(platform), wiiu)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	PLATCFLAGS += -DGEKKO -DWIIU -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__
-	PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+	PLATCFLAGS += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
 	STATIC_LINKING = 1
 
 # Nintendo Switch (libnx)


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)