### PR TITLE
Added recommended analog controls settings for Forgotten Worlds, Gond…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,14 @@ is longer than 1/60th of a second, but less than 2/60ths of a second.):
         - Key/Joy Speed: 21
         - Sensitivity: 100%
         - X-Way Joystick: On
+    * Forgotten Worlds (arcade version used "roll" button, not rotary joystick)
+        - Key/Joy Speed: 65
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * Gondomania
+        - Key/Joy Speed: 21
+        - Sensitivity: 100%
+        - X-Way Joystick: On
     * Guerrilla War
         - Key/Joy Speed: 16
         - Sensitivity: 100%
@@ -269,6 +277,10 @@ is longer than 1/60th of a second, but less than 2/60ths of a second.):
         - X-Way Joystick: On
     * SAR - Search and Rescue
         - Key/Joy Speed: 21
+        - Sensitivity: 100%
+        - X-Way Joystick: On
+    * T.A.N.K.
+        - Key/Joy Speed: 16
         - Sensitivity: 100%
         - X-Way Joystick: On
     * Time Soldiers

--- a/src/drivers/dec8.c
+++ b/src/drivers/dec8.c
@@ -32,7 +32,7 @@ To do:
 	Super Real Darwin 'Double' sprites appearing from the top of the screen are clipped
 	Strangely coloured butterfly on Garyo Retsuden water levels!
 
-  Thanks to José Miguel Morales Farreras for Super Real Darwin information!
+  Thanks to JosÃ© Miguel Morales Farreras for Super Real Darwin information!
 
 ***************************************************************************/
 
@@ -210,7 +210,7 @@ bb63           = Square things again
 (40)           = Grey bird
 (42)           = Crash (end of table)
 
-	The table below is hopefully correct thanks to José Miguel Morales Farreras,
+	The table below is hopefully correct thanks to JosÃ© Miguel Morales Farreras,
 	but Boss #6 is uncomfirmed as correct.
 
 */
@@ -1349,10 +1349,10 @@ INPUT_PORTS_START( gondo )
 	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_COIN2 )
 
 	PORT_START	/* player 1 12-way rotary control */
-	PORT_ANALOGX( 0xff, 0x00, IPT_DIAL | IPF_REVERSE, 25, 10, 0, 0, KEYCODE_Z, KEYCODE_X, IP_JOY_NONE, IP_JOY_NONE )
+	PORT_ANALOGX( 0xff, 0x0a, IPT_DIAL | IPF_REVERSE, 25, 10, 0, 0, KEYCODE_Z, KEYCODE_X, IP_JOY_NONE, IP_JOY_NONE )
 
 	PORT_START	/* player 2 12-way rotary control */
-	PORT_ANALOGX( 0xff, 0x00, IPT_DIAL | IPF_REVERSE | IPF_PLAYER2, 25, 10, 0, 0, KEYCODE_N, KEYCODE_M, IP_JOY_NONE, IP_JOY_NONE )
+	PORT_ANALOGX( 0xff, 0x0a, IPT_DIAL | IPF_REVERSE | IPF_PLAYER2, 25, 10, 0, 0, KEYCODE_N, KEYCODE_M, IP_JOY_NONE, IP_JOY_NONE )
 
 	PORT_START	/* Dip switch bank 1 */
 	PORT_DIPNAME( 0x03, 0x03, DEF_STR( Coin_A ) )


### PR DESCRIPTION
…omania, and T.A.N.K. Changed default Dial position so the character will not move 0 or 2 steps for at least 30 rotations in either direction.

Hi @mahoneyt944 , this should be the last x-way rotary joystick related PR for mame2003.  It is basically the same as this mame2003-plus PR, https://github.com/libretro/mame2003-plus-libretro/pull/1773 .

Per title, this adds recommended analog settings for 3 other games that use a rotary joystick (technically Forgotten worlds used a "roll" button, but I've never seen that sold anywhere, so a rotary joystick is a good substitute).

It also changes the default value for Gondomania, so with precession, the character can still rotary 30+ rotations without doing 0 or 2 rotations in either direction.

Thank you wanting to make a contribution to this project!

Please note that by contributing code or other intellectual to this project you are allowing the project to make unlimited use of your contribution. As with the rest of the project, new contributions will be made available freely under the classic MAME Non-Commercial License.

**This license can be viewed at https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md**.
